### PR TITLE
Windows-first support: git CLI backend, native TLS, tmux config + faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,32 +5,90 @@ on:
     branches: [master]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    name: Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+  lint:
+    name: Lint (ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.91.0
         with:
-          components: clippy, rustfmt, llvm-tools-preview
+          components: clippy, rustfmt
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  coverage:
+    name: Coverage (ubuntu-latest)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.91.0
+        with:
+          components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-      - name: Install tmux (macOS)
-        if: runner.os == 'macOS'
-        run: brew install tmux
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
       - name: Start persistent tmux server
         run: |
           # Create a dummy session to keep the server running
           tmux new-session -d -s keepalive 'sleep 3600'
-      - name: Run pre-commit
-        run: pre-commit run --all-files
+      - name: Run coverage
+        env:
+          TENEX_STATE_PATH: /tmp/tenex-ci-state.json
+        run: cargo llvm-cov --all-targets --all-features --profile coverage --fail-under-lines 90 --fail-under-functions 90 -- --test-threads=1
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    env:
+      CARGO_INCREMENTAL: 1
+      CARGO_PROFILE_DEV_CODEGEN_UNITS: 16
+      CARGO_PROFILE_TEST_CODEGEN_UNITS: 16
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
+      CARGO_PROFILE_RELEASE_LTO: false
+      CARGO_PROFILE_RELEASE_DEBUG: 0
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.91.0
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Install tmux (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Start persistent tmux server
+        if: runner.os == 'Linux'
+        run: |
+          # Create a dummy session to keep the server running
+          tmux new-session -d -s keepalive 'sleep 3600'
+      - name: Run tests
+        run: cargo test --all-targets --all-features -- --test-threads=1
+      - name: Build tenex (release)
+        if: runner.os == 'Linux' && github.event_name == 'push'
+        run: cargo build --release --locked
+      - name: Upload tenex artifact (Linux)
+        if: runner.os == 'Linux' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tenex-${{ matrix.os }}
+          path: target/release/tenex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,12 +134,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -200,10 +200,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
+name = "cookie"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -291,6 +320,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,27 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +353,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -384,6 +411,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -409,38 +450,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
 
 [[package]]
 name = "getrandom"
@@ -449,10 +462,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -462,11 +473,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -595,24 +604,6 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -621,22 +612,13 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
  "pin-project-lite",
- "socket2",
  "tokio",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -804,22 +786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,16 +845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,12 +903,6 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1006,6 +962,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,16 +1010,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
+name = "openssl-sys"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1076,6 +1081,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1157,61 +1171,6 @@ dependencies = [
  "rand_xorshift",
  "regex-syntax",
  "unarray",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.17",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1298,17 +1257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,46 +1290,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "reqwest"
-version = "0.12.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "ring"
@@ -1425,12 +1333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1373,7 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1480,24 +1383,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -1541,9 +1431,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1631,6 +1521,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1754,15 +1650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,23 +1681,22 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "dirs",
  "git2",
  "mockito",
  "pretty_assertions",
  "proptest",
  "ratatui",
- "reqwest",
  "rstest",
  "semver",
  "serde",
  "serde_json",
+ "shell-words",
  "tempfile",
  "thiserror 2.0.17",
- "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "ureq",
  "uuid",
 ]
 
@@ -1905,21 +1791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,33 +1799,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]
@@ -1969,51 +1816,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
-
-[[package]]
-name = "tower"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2060,12 +1862,6 @@ dependencies = [
  "tracing",
  "tracing-core",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unarray"
@@ -2115,6 +1911,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +1955,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2151,13 +1987,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "want"
-version = "0.3.1"
+name = "version_check"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -2185,19 +2018,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2233,23 +2053,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "webpki-root-certs"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
+name = "webpki-roots"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
 clap = { version = "4.5", default-features = false, features = ["derive", "std", "help"] }
-tokio = { version = "1.48", default-features = false, features = ["full"] }
-git2 = { version = "0.19", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 anyhow = { version = "1.0", default-features = false, features = ["std"] }
@@ -27,10 +25,16 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 tracing-appender = { version = "0.2", default-features = false }
 uuid = { version = "1.19", default-features = false, features = ["v4", "serde", "std"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock"] }
-dirs = { version = "6.0", default-features = false }
 ansi-to-tui = { version = "7.0", default-features = false }
-reqwest = { version = "0.12.25", default-features = false, features = ["blocking", "json", "rustls-tls-native-roots"] }
 semver = { version = "1.0.27", default-features = false, features = ["std"] }
+shell-words = { version = "1.1.1", default-features = false, features = ["std"] }
+
+[target.'cfg(not(windows))'.dependencies]
+git2 = { version = "0.19", default-features = false }
+ureq = { version = "3.1.4", default-features = false, features = ["json", "rustls"] }
+
+[target.'cfg(windows)'.dependencies]
+ureq = { version = "3.1.4", default-features = false, features = ["json", "native-tls"] }
 
 [dev-dependencies]
 tempfile = "3.19"

--- a/README.md
+++ b/README.md
@@ -33,10 +33,35 @@ Tenex lets you run multiple AI coding agents in parallel, each in an isolated gi
 ## Installation
 
 ```bash
+# Install from crates.io
+cargo install tenex --locked
+
 # Or build from source
 git clone https://github.com/Mockapapella/tenex
 cd tenex
 cargo install --path .
+```
+
+### Windows (native)
+
+Tenex builds cleanly with the Rust GNU toolchain. You still need MSYS2 for `tmux`, and it also
+provides `dlltool` for the GNU linker. Quick path:
+
+```powershell
+winget install --id MSYS2.MSYS2 -e
+C:\msys64\usr\bin\bash.exe -lc "pacman -S --needed tmux mingw-w64-x86_64-toolchain"
+setx TENEX_TMUX_BIN C:\msys64\usr\bin\tmux.exe
+rustup default stable-x86_64-pc-windows-gnu
+cargo install tenex --locked
+```
+
+### CI artifacts (no local build)
+
+Every CI run uploads `tenex` binaries for Linux/macOS/Windows. Download with `gh`:
+
+```bash
+gh run list -w CI -b <branch>
+gh run download <run-id> -n tenex-windows-latest
 ```
 
 ## Quick Start
@@ -114,7 +139,7 @@ The default agent command is `claude --allow-dangerously-skip-permissions`. Pres
 |------|----------|-------------|
 | State | `~/.local/share/tenex/state.json` | Agent list and hierarchy |
 | Settings | `~/.local/share/tenex/settings.json` | Tenex settings |
-| Logs | `/tmp/tenex.log` | Debug logs (when enabled) |
+| Logs | OS temp dir (e.g. `/tmp/tenex.log`) | Debug logs (when enabled) |
 
 ### Environment Variables
 

--- a/src/app/handlers/sync.rs
+++ b/src/app/handlers/sync.rs
@@ -120,7 +120,7 @@ impl Actions {
             );
 
             // Create tmux session and start the agent program
-            let command = program.clone();
+            let command = crate::command::build_command_argv(&program, None)?;
             self.session_manager
                 .create(&agent.tmux_session, &wt.path, Some(&command))?;
 

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -3,6 +3,7 @@
 //! Stores user preferences that persist across sessions, such as
 //! keyboard remapping choices.
 
+use crate::paths;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing::{debug, warn};
@@ -59,7 +60,7 @@ impl Settings {
     /// Get the settings file path
     #[must_use]
     pub fn path() -> PathBuf {
-        dirs::data_local_dir()
+        paths::data_local_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("tenex")
             .join("settings.json")

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,30 @@
+//! Command line parsing helpers.
+
+use anyhow::{Context, Result, bail};
+
+/// Split a command line into an argv vector.
+///
+/// This uses Unix shell-style quoting rules. Callers should treat the returned
+/// vector as an executable + arguments (not as a shell script).
+pub fn parse_command_line(command_line: &str) -> Result<Vec<String>> {
+    let trimmed = command_line.trim();
+    if trimmed.is_empty() {
+        bail!("Command line is empty");
+    }
+
+    let argv = shell_words::split(trimmed).context("Failed to parse command line")?;
+    if argv.is_empty() {
+        bail!("Command line produced no argv items");
+    }
+
+    Ok(argv)
+}
+
+/// Build an argv vector from a configured program string and an optional prompt.
+pub fn build_command_argv(program: &str, prompt: Option<&str>) -> Result<Vec<String>> {
+    let mut argv = parse_command_line(program)?;
+    if let Some(prompt) = prompt {
+        argv.push(prompt.to_string());
+    }
+    Ok(argv)
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ pub use keys::{
     Action, ActionGroup, get_action, get_display_description, get_display_keys, status_hints,
 };
 
+use crate::paths;
 use std::path::PathBuf;
 
 /// Application configuration (uses hardcoded defaults)
@@ -34,7 +35,7 @@ impl Default for Config {
             branch_prefix: "tenex/".to_string(),
             auto_yes: false,
             poll_interval_ms: 100,
-            worktree_dir: dirs::home_dir()
+            worktree_dir: paths::home_dir()
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join(".tenex")
                 .join("worktrees"),
@@ -52,7 +53,7 @@ impl Config {
         if let Ok(path) = std::env::var("TENEX_STATE_PATH") {
             return PathBuf::from(path);
         }
-        dirs::data_local_dir()
+        paths::data_local_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("tenex")
             .join("state.json")

--- a/src/git/branch_cli.rs
+++ b/src/git/branch_cli.rs
@@ -1,0 +1,250 @@
+//! Git branch management (CLI-based, Windows)
+
+use anyhow::{Context, Result, bail};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use super::{Repository, git_command, git_output, git_run};
+
+/// Information about a git branch for the branch selector
+#[derive(Debug, Clone)]
+pub struct BranchInfo {
+    /// Branch name (without remote prefix for remote branches)
+    pub name: String,
+    /// Full reference name (e.g., "refs/remotes/origin/main")
+    pub full_name: String,
+    /// Whether this is a remote branch
+    pub is_remote: bool,
+    /// Remote name (e.g., "origin") for remote branches
+    pub remote: Option<String>,
+    /// Last commit time (for sorting)
+    pub last_commit_time: Option<SystemTime>,
+}
+
+/// Manager for git branch operations
+pub struct Manager<'a> {
+    /// Repository handle
+    pub repo: &'a Repository,
+}
+
+impl std::fmt::Debug for Manager<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Manager").finish_non_exhaustive()
+    }
+}
+
+impl<'a> Manager<'a> {
+    /// Create a new branch manager for the given repository
+    #[must_use]
+    pub const fn new(repo: &'a Repository) -> Self {
+        Self { repo }
+    }
+
+    /// Create a new branch from HEAD
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the branch cannot be created
+    pub fn create(&self, name: &str) -> Result<()> {
+        git_run(&self.repo.root, &["branch", name])
+            .with_context(|| format!("Failed to create branch '{name}'"))
+    }
+
+    /// Create a new branch from a specific commit
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the branch cannot be created
+    pub fn create_from_commit(&self, name: &str, commit_id: &str) -> Result<()> {
+        git_run(&self.repo.root, &["branch", name, commit_id])
+            .with_context(|| format!("Failed to create branch '{name}' at {commit_id}"))
+    }
+
+    /// Delete a local branch
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the branch cannot be deleted
+    pub fn delete(&self, name: &str) -> Result<()> {
+        git_run(&self.repo.root, &["branch", "-D", name])
+            .with_context(|| format!("Failed to delete branch '{name}'"))
+    }
+
+    /// Check if a branch exists
+    #[must_use]
+    pub fn exists(&self, name: &str) -> bool {
+        let status = git_command()
+            .args([
+                "show-ref",
+                "--verify",
+                "--quiet",
+                &format!("refs/heads/{name}"),
+            ])
+            .current_dir(&self.repo.root)
+            .status();
+
+        status.map(|s| s.success()).unwrap_or(false)
+    }
+
+    /// Get the current branch name
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HEAD is not a branch
+    pub fn current(&self) -> Result<String> {
+        let name = git_output(&self.repo.root, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .context("Failed to get HEAD")?;
+        if name == "HEAD" {
+            bail!("HEAD is not a branch (detached HEAD state)");
+        }
+        Ok(name)
+    }
+
+    /// List all local branches
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if branches cannot be listed
+    pub fn list(&self) -> Result<Vec<String>> {
+        let output = git_output(
+            &self.repo.root,
+            &["for-each-ref", "--format=%(refname:short)", "refs/heads"],
+        )
+        .context("Failed to list branches")?;
+
+        Ok(output
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(String::from)
+            .collect())
+    }
+
+    /// Checkout a branch
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the branch cannot be checked out
+    pub fn checkout(&self, name: &str) -> Result<()> {
+        git_run(&self.repo.root, &["checkout", name])
+            .with_context(|| format!("Failed to checkout branch '{name}'"))
+    }
+
+    /// Get the commit count on a branch
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the branch or commits cannot be read
+    pub fn commit_count(&self, name: &str) -> Result<usize> {
+        let output = git_output(&self.repo.root, &["rev-list", "--count", name])
+            .with_context(|| format!("Failed to read commit count for '{name}'"))?;
+        let count = output
+            .parse::<usize>()
+            .with_context(|| format!("Invalid commit count '{output}'"))?;
+        Ok(count)
+    }
+
+    /// List all branches for the branch selector
+    ///
+    /// Returns branches sorted with:
+    /// - "main" and "master" at the top (if they exist)
+    /// - Local branches before remote branches
+    /// - Within each section, sorted by most recent commit
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if branches cannot be listed
+    pub fn list_for_selector(&self) -> Result<Vec<BranchInfo>> {
+        let output = git_output(
+            &self.repo.root,
+            &[
+                "for-each-ref",
+                "--format=%(refname)\t%(refname:short)\t%(committerdate:unix)",
+                "refs/heads",
+                "refs/remotes",
+            ],
+        )
+        .context("Failed to list branches")?;
+
+        let mut local_branches = Vec::new();
+        let mut remote_branches = Vec::new();
+
+        for line in output.lines() {
+            let mut parts = line.splitn(3, '\t');
+            let Some(ref_name) = parts.next() else {
+                continue;
+            };
+            let Some(short_name) = parts.next() else {
+                continue;
+            };
+            let commit_time = parts
+                .next()
+                .and_then(|t| t.parse::<u64>().ok())
+                .and_then(|secs| UNIX_EPOCH.checked_add(Duration::from_secs(secs)));
+
+            if ref_name.starts_with("refs/remotes/") {
+                if short_name.ends_with("/HEAD") {
+                    continue;
+                }
+
+                let mut short_parts = short_name.splitn(2, '/');
+                let remote_name = short_parts.next().map(str::to_string);
+                let branch_name = short_parts
+                    .next()
+                    .map_or_else(|| short_name.to_string(), str::to_string);
+
+                remote_branches.push(BranchInfo {
+                    name: branch_name,
+                    full_name: ref_name.to_string(),
+                    is_remote: true,
+                    remote: remote_name,
+                    last_commit_time: commit_time,
+                });
+            } else if ref_name.starts_with("refs/heads/") {
+                local_branches.push(BranchInfo {
+                    name: short_name.to_string(),
+                    full_name: ref_name.to_string(),
+                    is_remote: false,
+                    remote: None,
+                    last_commit_time: commit_time,
+                });
+            }
+        }
+
+        // Sort local branches: main/master first, then by most recent commit
+        local_branches.sort_by(|a, b| {
+            let a_priority = Self::branch_priority(&a.name);
+            let b_priority = Self::branch_priority(&b.name);
+
+            // Higher priority first (main/master)
+            match b_priority.cmp(&a_priority) {
+                std::cmp::Ordering::Equal => b.last_commit_time.cmp(&a.last_commit_time),
+                other => other,
+            }
+        });
+
+        // Sort remote branches: main/master first, then by most recent commit
+        remote_branches.sort_by(|a, b| {
+            let a_priority = Self::branch_priority(&a.name);
+            let b_priority = Self::branch_priority(&b.name);
+
+            match b_priority.cmp(&a_priority) {
+                std::cmp::Ordering::Equal => b.last_commit_time.cmp(&a.last_commit_time),
+                other => other,
+            }
+        });
+
+        // Combine: local branches first, then remote
+        let mut result = local_branches;
+        result.extend(remote_branches);
+        Ok(result)
+    }
+
+    /// Get priority for branch name sorting (higher = comes first)
+    fn branch_priority(name: &str) -> u8 {
+        match name {
+            "main" => 2,
+            "master" => 1,
+            _ => 0,
+        }
+    }
+}

--- a/src/git/diff_cli.rs
+++ b/src/git/diff_cli.rs
@@ -1,0 +1,461 @@
+//! Git diff generation (CLI-based, Windows)
+
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::{Repository, git_output};
+
+/// Generator for git diffs
+pub struct Generator<'a> {
+    /// Repository handle
+    pub repo: &'a Repository,
+}
+
+impl std::fmt::Debug for Generator<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Generator").finish_non_exhaustive()
+    }
+}
+
+impl<'a> Generator<'a> {
+    /// Create a new diff generator for the given repository
+    #[must_use]
+    pub const fn new(repo: &'a Repository) -> Self {
+        Self { repo }
+    }
+
+    /// Get unstaged changes (working directory vs index)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the diff cannot be generated
+    pub fn unstaged(&self) -> Result<Vec<FileChange>> {
+        let patch = git_output(
+            &self.repo.root,
+            &["diff", "--no-color", "--patch", "--no-ext-diff"],
+        )
+        .context("Failed to get unstaged diff")?;
+
+        let mut files = parse_patch(&patch);
+        add_untracked(&self.repo.root, &mut files)?;
+        Ok(files)
+    }
+
+    /// Get staged changes (index vs HEAD)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the diff cannot be generated
+    pub fn staged(&self) -> Result<Vec<FileChange>> {
+        let patch = git_output(
+            &self.repo.root,
+            &["diff", "--cached", "--no-color", "--patch", "--no-ext-diff"],
+        )
+        .context("Failed to get staged diff")?;
+
+        Ok(parse_patch(&patch))
+    }
+
+    /// Get all uncommitted changes (working directory vs HEAD)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the diff cannot be generated
+    pub fn uncommitted(&self) -> Result<Vec<FileChange>> {
+        let patch = git_output(
+            &self.repo.root,
+            &["diff", "HEAD", "--no-color", "--patch", "--no-ext-diff"],
+        )
+        .context("Failed to get uncommitted diff")?;
+
+        let mut files = parse_patch(&patch);
+        add_untracked(&self.repo.root, &mut files)?;
+        Ok(files)
+    }
+
+    /// Get diff between two commits
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the commits cannot be found or diff cannot be generated
+    pub fn between_commits(&self, old_commit: &str, new_commit: &str) -> Result<Vec<FileChange>> {
+        let patch = git_output(
+            &self.repo.root,
+            &[
+                "diff",
+                old_commit,
+                new_commit,
+                "--no-color",
+                "--patch",
+                "--no-ext-diff",
+            ],
+        )
+        .with_context(|| format!("Failed to diff {old_commit}..{new_commit}"))?;
+
+        Ok(parse_patch(&patch))
+    }
+
+    /// Get diff between a branch and HEAD
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the diff cannot be generated
+    pub fn branch_diff(&self, branch: &str) -> Result<Vec<FileChange>> {
+        self.between_commits(branch, "HEAD")
+    }
+
+    /// Get a summary of changes (files changed, additions, deletions)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the diff cannot be generated
+    pub fn summary(&self) -> Result<Summary> {
+        let files = self.uncommitted()?;
+
+        let additions: usize = files.iter().map(|f| f.additions).sum();
+        let deletions: usize = files.iter().map(|f| f.deletions).sum();
+
+        Ok(Summary {
+            files_changed: files.len(),
+            additions,
+            deletions,
+        })
+    }
+
+    /// Check if there are any uncommitted changes
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the status cannot be checked
+    pub fn has_changes(&self) -> Result<bool> {
+        let output = git_output(
+            &self.repo.root,
+            &["status", "--porcelain", "--untracked-files=normal"],
+        )
+        .context("Failed to get repository status")?;
+        Ok(!output.trim().is_empty())
+    }
+}
+
+fn parse_patch(patch: &str) -> Vec<FileChange> {
+    let mut files = Vec::new();
+    let mut current: Option<FileChange> = None;
+
+    for raw_line in patch.split_inclusive('\n') {
+        let line = raw_line.trim_end_matches(['\r', '\n']);
+
+        if let Some(rest) = line.strip_prefix("diff --git ") {
+            if let Some(file) = current.take() {
+                files.push(file);
+            }
+
+            let mut parts = rest.split_whitespace();
+            let a_path = parts.next().unwrap_or("");
+            let b_path = parts.next().unwrap_or("");
+            let diff_path = normalize_diff_path(b_path).or_else(|| normalize_diff_path(a_path));
+
+            if let Some(diff_path) = diff_path {
+                let file = FileChange {
+                    path: diff_path,
+                    status: FileStatus::Modified,
+                    lines: Vec::new(),
+                    additions: 0,
+                    deletions: 0,
+                };
+                current = Some(file);
+            }
+            continue;
+        }
+
+        let Some(file) = current.as_mut() else {
+            continue;
+        };
+
+        if let Some(status) = parse_status_line(line, file) {
+            file.status = status;
+            continue;
+        }
+
+        if is_diff_header(line) {
+            continue;
+        }
+
+        if let Some(line_change) = parse_line_change(line, raw_line) {
+            match line_change {
+                LineChange::Added(_) => file.additions += 1,
+                LineChange::Removed(_) => file.deletions += 1,
+                LineChange::Context(_) => {}
+            }
+            file.lines.push(line_change);
+        }
+    }
+
+    if let Some(file) = current.take() {
+        files.push(file);
+    }
+
+    // Deduplicate by path while preserving first occurrence
+    if files.len() > 1 {
+        let mut unique = Vec::new();
+        let mut seen = HashSet::new();
+        for file in files {
+            if seen.insert(file.path.clone()) {
+                unique.push(file);
+            }
+        }
+        unique
+    } else {
+        files
+    }
+}
+
+fn normalize_diff_path(token: &str) -> Option<PathBuf> {
+    let trimmed = token.trim_matches('"');
+    let trimmed = trimmed
+        .strip_prefix("a/")
+        .or_else(|| trimmed.strip_prefix("b/"))?;
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+fn parse_status_line(line: &str, file: &mut FileChange) -> Option<FileStatus> {
+    if let Some(path) = line.strip_prefix("rename to ") {
+        file.path = PathBuf::from(path.trim());
+        return Some(FileStatus::Renamed);
+    }
+    if line.starts_with("rename from ") {
+        return Some(FileStatus::Renamed);
+    }
+    if let Some(path) = line.strip_prefix("copy to ") {
+        file.path = PathBuf::from(path.trim());
+        return Some(FileStatus::Copied);
+    }
+    if line.starts_with("copy from ") {
+        return Some(FileStatus::Copied);
+    }
+    if line.starts_with("new file mode ") {
+        return Some(FileStatus::Added);
+    }
+    if line.starts_with("deleted file mode ") {
+        return Some(FileStatus::Deleted);
+    }
+    if line.starts_with("old mode ") || line.starts_with("new mode ") {
+        return Some(FileStatus::TypeChange);
+    }
+    None
+}
+
+fn is_diff_header(line: &str) -> bool {
+    line.starts_with("index ")
+        || line.starts_with("@@ ")
+        || line.starts_with("@@@ ")
+        || line.starts_with("--- ")
+        || line.starts_with("+++ ")
+}
+
+fn parse_line_change(line: &str, raw_line: &str) -> Option<LineChange> {
+    if line.starts_with('+') && !line.starts_with("+++") {
+        return Some(LineChange::Added(raw_line.to_string()));
+    }
+    if line.starts_with('-') && !line.starts_with("---") {
+        return Some(LineChange::Removed(raw_line.to_string()));
+    }
+    if line.starts_with(' ') {
+        return Some(LineChange::Context(raw_line.to_string()));
+    }
+    if line.starts_with('\\') {
+        return Some(LineChange::Context(raw_line.to_string()));
+    }
+    None
+}
+
+fn add_untracked(repo_root: &Path, files: &mut Vec<FileChange>) -> Result<()> {
+    let output = git_output(repo_root, &["ls-files", "--others", "--exclude-standard"])
+        .context("Failed to list untracked files")?;
+
+    for line in output.lines() {
+        let rel_path = line.trim();
+        if rel_path.is_empty() {
+            continue;
+        }
+
+        let path = PathBuf::from(rel_path);
+        if files.iter().any(|f| f.path == path) {
+            continue;
+        }
+
+        let abs_path = repo_root.join(&path);
+        let contents = match std::fs::read(&abs_path) {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+            Err(err) => {
+                let file = FileChange {
+                    path,
+                    status: FileStatus::Untracked,
+                    lines: vec![LineChange::Context(format!("Unable to read file: {err}\n"))],
+                    additions: 0,
+                    deletions: 0,
+                };
+                files.push(file);
+                continue;
+            }
+        };
+
+        if contents.is_empty() {
+            files.push(FileChange {
+                path,
+                status: FileStatus::Untracked,
+                lines: Vec::new(),
+                additions: 0,
+                deletions: 0,
+            });
+            continue;
+        }
+
+        let ends_with_newline = contents.ends_with('\n');
+        let mut parts: Vec<&str> = contents.split('\n').collect();
+        if ends_with_newline {
+            parts.pop();
+        }
+
+        let mut line_changes = Vec::new();
+        let mut additions = 0;
+        for (idx, line) in parts.iter().enumerate() {
+            let mut rendered = (*line).to_string();
+            if idx + 1 < parts.len() || ends_with_newline {
+                rendered.push('\n');
+            }
+            additions += 1;
+            line_changes.push(LineChange::Added(rendered));
+        }
+
+        files.push(FileChange {
+            path,
+            status: FileStatus::Untracked,
+            lines: line_changes,
+            additions,
+            deletions: 0,
+        });
+    }
+
+    Ok(())
+}
+
+/// Represents a single file's diff
+#[derive(Debug, Clone)]
+pub struct FileChange {
+    /// Path to the file
+    pub path: PathBuf,
+    /// Status of the file (added, modified, deleted, etc.)
+    pub status: FileStatus,
+    /// Lines of the diff
+    pub lines: Vec<LineChange>,
+    /// Number of lines added
+    pub additions: usize,
+    /// Number of lines deleted
+    pub deletions: usize,
+}
+
+impl FileChange {
+    /// Get the diff as a formatted string
+    #[must_use]
+    pub fn to_string_colored(&self) -> String {
+        let mut output = String::new();
+        output.push_str("--- a/");
+        output.push_str(&self.path.display().to_string());
+        output.push_str("\n+++ b/");
+        output.push_str(&self.path.display().to_string());
+        output.push('\n');
+
+        for line in &self.lines {
+            match line {
+                LineChange::Added(content) => {
+                    output.push('+');
+                    output.push_str(content);
+                }
+                LineChange::Removed(content) => {
+                    output.push('-');
+                    output.push_str(content);
+                }
+                LineChange::Context(content) => {
+                    output.push(' ');
+                    output.push_str(content);
+                }
+            }
+        }
+
+        output
+    }
+}
+
+/// A single line in a diff
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LineChange {
+    /// Line was added
+    Added(String),
+    /// Line was removed
+    Removed(String),
+    /// Context line (unchanged)
+    Context(String),
+}
+
+/// Status of a file in the diff
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileStatus {
+    /// File was added
+    Added,
+    /// File was deleted
+    Deleted,
+    /// File was modified
+    Modified,
+    /// File was renamed
+    Renamed,
+    /// File was copied
+    Copied,
+    /// File type changed
+    TypeChange,
+    /// Untracked file
+    Untracked,
+    /// Unknown status
+    Unknown,
+}
+
+impl std::fmt::Display for FileStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Added => "A",
+            Self::Deleted => "D",
+            Self::Modified => "M",
+            Self::Renamed => "R",
+            Self::Copied => "C",
+            Self::TypeChange => "T",
+            Self::Untracked => "?",
+            Self::Unknown => "X",
+        };
+        write!(f, "{s}")
+    }
+}
+
+/// Summary of diff statistics
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Summary {
+    /// Number of files changed
+    pub files_changed: usize,
+    /// Total lines added
+    pub additions: usize,
+    /// Total lines deleted
+    pub deletions: usize,
+}
+
+impl std::fmt::Display for Summary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} file(s) changed, {} insertion(s), {} deletion(s)",
+            self.files_changed, self.additions, self.deletions
+        )
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,33 +1,154 @@
 //! Git operations module
 
+#[cfg(not(windows))]
 mod branch;
+#[cfg(windows)]
+mod branch_cli;
+
+#[cfg(not(windows))]
 mod diff;
+#[cfg(windows)]
+mod diff_cli;
+
+#[cfg(not(windows))]
 mod worktree;
+#[cfg(windows)]
+mod worktree_cli;
 
+#[cfg(not(windows))]
 pub use branch::{BranchInfo, Manager as BranchManager};
-pub use diff::{FileChange, Generator as DiffGenerator, LineChange, Summary as DiffSummary};
-pub use worktree::{Info as WorktreeInfo, Manager as WorktreeManager};
+#[cfg(windows)]
+pub use branch_cli::{BranchInfo, Manager as BranchManager};
 
+#[cfg(not(windows))]
+pub use diff::{FileChange, Generator as DiffGenerator, LineChange, Summary as DiffSummary};
+#[cfg(windows)]
+pub use diff_cli::{FileChange, Generator as DiffGenerator, LineChange, Summary as DiffSummary};
+
+#[cfg(not(windows))]
+pub use worktree::{Info as WorktreeInfo, Manager as WorktreeManager};
+#[cfg(windows)]
+pub use worktree_cli::{Info as WorktreeInfo, Manager as WorktreeManager};
+
+#[cfg(windows)]
+use anyhow::bail;
 use anyhow::{Context, Result};
-use git2::Repository;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
+#[cfg(any(windows, test))]
+use std::path::PathBuf;
+use std::process::Command;
+
+#[cfg(not(windows))]
+pub use git2::Repository;
+
+#[cfg(windows)]
+/// Lightweight repository metadata for CLI-based operations.
+#[derive(Debug, Clone)]
+pub struct Repository {
+    /// Root working directory of the repository.
+    pub root: PathBuf,
+}
+
+/// Create a `git` command for Tenex.
+///
+/// Git hooks can set variables like `GIT_DIR` which override repository discovery and ignore
+/// `current_dir`. Clearing these for child processes ensures Tenex operates on the intended
+/// worktree repositories.
+#[must_use]
+pub(crate) fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_NAMESPACE",
+        "GIT_PREFIX",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+#[cfg(windows)]
+pub(crate) fn git_output(repo_root: &Path, args: &[&str]) -> Result<String> {
+    let output = git_command()
+        .args(args)
+        .current_dir(repo_root)
+        .output()
+        .with_context(|| format!("Failed to execute git {}", args.join(" ")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if stderr.is_empty() {
+            bail!(
+                "git {} failed with status {}",
+                args.join(" "),
+                output.status
+            );
+        }
+        bail!("git {} failed: {stderr}", args.join(" "));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(windows)]
+pub(crate) fn git_run(repo_root: &Path, args: &[&str]) -> Result<()> {
+    git_output(repo_root, args)?;
+    Ok(())
+}
 
 /// Open a git repository at the given path
 ///
 /// # Errors
 ///
 /// Returns an error if the path is not a git repository
+#[cfg(not(windows))]
 pub fn open_repository(path: &Path) -> Result<Repository> {
     Repository::discover(path)
         .with_context(|| format!("Failed to open git repository at {}", path.display()))
 }
 
+#[cfg(windows)]
+/// Open a git repository at the given path
+///
+/// # Errors
+///
+/// Returns an error if the path is not a git repository
+pub fn open_repository(path: &Path) -> Result<Repository> {
+    let root = git_output(path, &["rev-parse", "--show-toplevel"])
+        .with_context(|| format!("Failed to open git repository at {}", path.display()))?;
+    let root_path = PathBuf::from(root);
+    let root = if root_path.is_absolute() {
+        root_path
+    } else {
+        path.join(root_path)
+    };
+    Ok(Repository { root })
+}
+
 /// Check if a path is inside a git repository
+#[cfg(not(windows))]
 #[must_use]
 pub fn is_git_repository(path: &Path) -> bool {
     Repository::discover(path).is_ok()
+}
+
+#[cfg(windows)]
+/// Check if a path is inside a git repository
+#[must_use]
+pub fn is_git_repository(path: &Path) -> bool {
+    git_command()
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(path)
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
+        .unwrap_or(false)
 }
 
 /// Get the root of the git repository containing the given path
@@ -35,11 +156,23 @@ pub fn is_git_repository(path: &Path) -> bool {
 /// # Errors
 ///
 /// Returns an error if the path is not inside a git repository
+#[cfg(not(windows))]
 pub fn repository_root(path: &Path) -> Result<std::path::PathBuf> {
     let repo = open_repository(path)?;
     repo.workdir()
         .map(std::path::Path::to_path_buf)
         .context("Repository has no working directory")
+}
+
+#[cfg(windows)]
+/// Get the root of the git repository containing the given path
+///
+/// # Errors
+///
+/// Returns an error if the path is not inside a git repository
+pub fn repository_root(path: &Path) -> Result<std::path::PathBuf> {
+    let repo = open_repository(path)?;
+    Ok(repo.root)
 }
 
 /// Ensure `.tenex/` is in `.git/info/exclude`
@@ -50,6 +183,7 @@ pub fn repository_root(path: &Path) -> Result<std::path::PathBuf> {
 /// # Errors
 ///
 /// Returns an error if the exclude file cannot be read or written
+#[cfg(not(windows))]
 pub fn ensure_tenex_excluded(repo_path: &Path) -> Result<()> {
     const EXCLUDE_ENTRY: &str = ".tenex/";
 
@@ -92,20 +226,84 @@ pub fn ensure_tenex_excluded(repo_path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
+/// Ensure `.tenex/` is in `.git/info/exclude`
+///
+/// This prevents synthesis files from being tracked by git.
+/// Creates the exclude file if it doesn't exist.
+///
+/// # Errors
+///
+/// Returns an error if the exclude file cannot be read or written
+pub fn ensure_tenex_excluded(repo_path: &Path) -> Result<()> {
+    const EXCLUDE_ENTRY: &str = ".tenex/";
+
+    let repo = open_repository(repo_path)?;
+    let exclude_path = git_path(&repo.root, "info/exclude")?;
+
+    if let Some(parent) = exclude_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+    }
+
+    if exclude_path.exists() {
+        let file = fs::File::open(&exclude_path)
+            .with_context(|| format!("Failed to open {}", exclude_path.display()))?;
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            let line = line.context("Failed to read exclude file")?;
+            if line.trim() == EXCLUDE_ENTRY {
+                return Ok(());
+            }
+        }
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude_path)
+        .with_context(|| format!("Failed to open {} for writing", exclude_path.display()))?;
+
+    writeln!(file, "{EXCLUDE_ENTRY}")
+        .with_context(|| format!("Failed to write to {}", exclude_path.display()))?;
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn git_path(repo_root: &Path, git_path: &str) -> Result<PathBuf> {
+    let path = git_output(repo_root, &["rev-parse", "--git-path", git_path])?;
+    let path_buf = PathBuf::from(path);
+    if path_buf.is_absolute() {
+        Ok(path_buf)
+    } else {
+        Ok(repo_root.join(path_buf))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn init_test_repo() -> Result<(TempDir, Repository), Box<dyn std::error::Error>> {
+    fn init_test_repo() -> Result<TempDir, Box<dyn std::error::Error>> {
         let temp_dir = TempDir::new()?;
-        let repo = Repository::init(temp_dir.path())?;
-        Ok((temp_dir, repo))
+        let output = git_command()
+            .args(["init"])
+            .current_dir(temp_dir.path())
+            .output()?;
+        if !output.status.success() {
+            return Err("Failed to initialize test repo".into());
+        }
+        Ok(temp_dir)
     }
 
     #[test]
     fn test_is_git_repository() -> Result<(), Box<dyn std::error::Error>> {
-        let (temp_dir, _repo) = init_test_repo()?;
+        let temp_dir = init_test_repo()?;
         assert!(is_git_repository(temp_dir.path()));
 
         let non_repo = TempDir::new()?;
@@ -115,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_open_repository() -> Result<(), Box<dyn std::error::Error>> {
-        let (temp_dir, _repo) = init_test_repo()?;
+        let temp_dir = init_test_repo()?;
         assert!(open_repository(temp_dir.path()).is_ok());
 
         let non_repo = TempDir::new()?;
@@ -125,7 +323,7 @@ mod tests {
 
     #[test]
     fn test_repository_root() -> Result<(), Box<dyn std::error::Error>> {
-        let (temp_dir, _repo) = init_test_repo()?;
+        let temp_dir = init_test_repo()?;
         let root = repository_root(temp_dir.path())?;
         // Canonicalize both paths to handle macOS /var -> /private/var symlink
         let expected = temp_dir.path().canonicalize()?;
@@ -136,12 +334,12 @@ mod tests {
 
     #[test]
     fn test_ensure_tenex_excluded() -> Result<(), Box<dyn std::error::Error>> {
-        let (temp_dir, _repo) = init_test_repo()?;
+        let temp_dir = init_test_repo()?;
 
         // First call should add .tenex/ to exclude
         ensure_tenex_excluded(temp_dir.path())?;
 
-        let exclude_path = temp_dir.path().join(".git/info/exclude");
+        let exclude_path = exclude_path_for_test(temp_dir.path())?;
         assert!(exclude_path.exists());
 
         let contents = std::fs::read_to_string(&exclude_path)?;
@@ -159,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_ensure_tenex_excluded_creates_info_dir() -> Result<(), Box<dyn std::error::Error>> {
-        let (temp_dir, _repo) = init_test_repo()?;
+        let temp_dir = init_test_repo()?;
 
         // Remove the info directory if it exists
         let info_dir = temp_dir.path().join(".git/info");
@@ -175,5 +373,22 @@ mod tests {
         assert!(exclude_path.exists());
 
         Ok(())
+    }
+
+    fn exclude_path_for_test(repo_path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let output = git_command()
+            .args(["rev-parse", "--git-path", "info/exclude"])
+            .current_dir(repo_path)
+            .output()?;
+        if !output.status.success() {
+            return Err("Failed to resolve .git info/exclude".into());
+        }
+        let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let path = PathBuf::from(raw);
+        if path.is_absolute() {
+            Ok(path)
+        } else {
+            Ok(repo_path.join(path))
+        }
     }
 }

--- a/src/git/worktree_cli.rs
+++ b/src/git/worktree_cli.rs
@@ -1,0 +1,443 @@
+//! Git worktree management (CLI-based, Windows)
+
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tracing::{debug, info, warn};
+
+use super::{Repository, git_command, git_output, git_run};
+
+#[expect(
+    clippy::permissions_set_readonly_false,
+    reason = "Windows worktree cleanup needs to clear the read-only attribute"
+)]
+fn clear_readonly_recursive(root: &Path) {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        if let Ok(metadata) = fs::metadata(&path) {
+            let mut permissions = metadata.permissions();
+            if permissions.readonly() {
+                permissions.set_readonly(false);
+                if let Err(e) = fs::set_permissions(&path, permissions) {
+                    warn!(path = ?path, error = %e, "Failed to clear read-only attribute");
+                }
+            }
+        }
+
+        if let Ok(entries) = fs::read_dir(&path) {
+            for entry in entries.flatten() {
+                let child = entry.path();
+                if child.is_dir() {
+                    stack.push(child);
+                } else if let Ok(metadata) = entry.metadata() {
+                    let mut permissions = metadata.permissions();
+                    if permissions.readonly() {
+                        permissions.set_readonly(false);
+                        if let Err(e) = fs::set_permissions(&child, permissions) {
+                            warn!(path = ?child, error = %e, "Failed to clear read-only attribute");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn remove_dir_all_with_retries(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let mut last_err = None;
+    for attempt in 0u64..10 {
+        match fs::remove_dir_all(path) {
+            Ok(()) => {
+                last_err = None;
+                break;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                last_err = None;
+                break;
+            }
+            Err(e) => {
+                last_err = Some(e);
+                clear_readonly_recursive(path);
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100 * (attempt + 1)));
+
+        if !path.exists() {
+            last_err = None;
+            break;
+        }
+    }
+
+    if path.exists() {
+        let Some(e) = last_err else {
+            bail!("Failed to remove directory at {}", path.display());
+        };
+        bail!("Failed to remove directory at {}: {e}", path.display());
+    }
+
+    Ok(())
+}
+
+/// Manager for git worktree operations
+pub struct Manager<'a> {
+    /// Repository handle
+    pub repo: &'a Repository,
+}
+
+impl std::fmt::Debug for Manager<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Manager").finish_non_exhaustive()
+    }
+}
+
+impl<'a> Manager<'a> {
+    /// Create a new worktree manager for the given repository
+    #[must_use]
+    pub const fn new(repo: &'a Repository) -> Self {
+        Self { repo }
+    }
+
+    /// Create a new worktree for a branch
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worktree cannot be created
+    pub fn create(&self, path: &Path, branch: &str) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create parent directory {}", parent.display())
+            })?;
+        }
+
+        let path_str = path.to_str().context("Worktree path is not valid UTF-8")?;
+        git_run(&self.repo.root, &["worktree", "add", path_str, branch]).with_context(|| {
+            format!(
+                "Failed to create worktree at {} for {branch}",
+                path.display()
+            )
+        })
+    }
+
+    /// Create a worktree with a new branch from HEAD
+    ///
+    /// If the branch already exists (e.g., from a previous run), it will be deleted
+    /// and recreated from HEAD.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worktree or branch cannot be created
+    pub fn create_with_new_branch(&self, path: &Path, branch: &str) -> Result<()> {
+        debug!(branch, ?path, "Creating worktree with new branch");
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create parent directory {}", parent.display())
+            })?;
+        }
+
+        if self.exists(branch) {
+            debug!(branch, "Removing existing worktree before recreation");
+            self.remove(branch)?;
+        }
+
+        let branch_mgr = super::BranchManager::new(self.repo);
+        if branch_mgr.exists(branch) {
+            debug!(branch, "Deleting existing branch before recreation");
+            branch_mgr.delete(branch)?;
+        }
+
+        let path_str = path.to_str().context("Worktree path is not valid UTF-8")?;
+        git_run(
+            &self.repo.root,
+            &["worktree", "add", "-b", branch, path_str],
+        )
+        .with_context(|| format!("Failed to create worktree at {}", path.display()))?;
+
+        info!(branch, ?path, "Worktree created");
+        Ok(())
+    }
+
+    /// Remove a worktree and its associated branch
+    ///
+    /// Always attempts to delete the branch, even if the worktree is missing.
+    /// This ensures cleanup works even if the worktree was manually removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worktree exists but cannot be removed after retries.
+    /// Does not return errors for missing worktrees or branches.
+    pub fn remove(&self, name: &str) -> Result<()> {
+        debug!(name, "Removing worktree and branch");
+
+        if let Some(record) = find_worktree_by_branch(&self.repo.root, name)? {
+            let path_str = record
+                .path
+                .to_str()
+                .context("Worktree path is not valid UTF-8")?;
+
+            let output = git_command()
+                .args(["worktree", "remove", "--force", path_str])
+                .current_dir(&self.repo.root)
+                .output()
+                .context("Failed to execute git worktree remove")?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                warn!(name, path = %path_str, "git worktree remove failed: {stderr}");
+            }
+
+            if let Err(e) = remove_dir_all_with_retries(&record.path) {
+                warn!(name, path = ?record.path, error = %e, "Failed to remove worktree directory");
+                return Err(e);
+            }
+
+            if let Err(e) = git_run(&self.repo.root, &["worktree", "prune"]) {
+                warn!(name, error = %e, "Failed to prune worktrees after removal");
+            }
+        }
+
+        let branch_mgr = super::BranchManager::new(self.repo);
+        if let Err(e) = branch_mgr.delete(name) {
+            warn!(name, error = %e, "Failed to delete branch during worktree cleanup");
+        }
+
+        info!(name, "Worktree removed");
+        Ok(())
+    }
+
+    /// List all worktrees
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if worktrees cannot be listed
+    pub fn list(&self) -> Result<Vec<Info>> {
+        let records = list_worktrees(&self.repo.root)?;
+        let mut infos = Vec::new();
+        for record in records {
+            let name = record
+                .branch
+                .as_deref()
+                .and_then(|branch| branch.strip_prefix("refs/heads/"))
+                .map(str::to_string)
+                .or_else(|| {
+                    record
+                        .path
+                        .file_name()
+                        .map(|name| name.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| "(unknown)".to_string());
+
+            infos.push(Info {
+                name,
+                path: record.path,
+                is_locked: record.is_locked,
+            });
+        }
+
+        Ok(infos)
+    }
+
+    /// Check if a worktree exists
+    #[must_use]
+    pub fn exists(&self, name: &str) -> bool {
+        find_worktree_by_branch(&self.repo.root, name)
+            .map(|entry| entry.is_some())
+            .unwrap_or(false)
+    }
+
+    /// Lock a worktree to prevent it from being pruned
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worktree cannot be locked
+    pub fn lock(&self, name: &str, reason: Option<&str>) -> Result<()> {
+        let record = find_worktree_by_branch(&self.repo.root, name)?
+            .with_context(|| format!("Worktree not found: {name}"))?;
+
+        let path_str = record
+            .path
+            .to_str()
+            .context("Worktree path is not valid UTF-8")?;
+
+        let mut args = vec!["worktree", "lock"];
+        let mut owned = Vec::new();
+        if let Some(reason) = reason {
+            owned.push("--reason".to_string());
+            owned.push(reason.to_string());
+        }
+        for item in owned.iter() {
+            args.push(item);
+        }
+        args.push(path_str);
+
+        git_run(&self.repo.root, &args).with_context(|| format!("Failed to lock worktree '{name}'"))
+    }
+
+    /// Unlock a worktree
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worktree cannot be unlocked
+    pub fn unlock(&self, name: &str) -> Result<()> {
+        let record = find_worktree_by_branch(&self.repo.root, name)?
+            .with_context(|| format!("Worktree not found: {name}"))?;
+
+        if !record.is_locked {
+            bail!("Worktree '{name}' is not locked");
+        }
+
+        let path_str = record
+            .path
+            .to_str()
+            .context("Worktree path is not valid UTF-8")?;
+
+        git_run(&self.repo.root, &["worktree", "unlock", path_str])
+            .with_context(|| format!("Failed to unlock worktree '{name}'"))
+    }
+
+    /// Validate a worktree (check if it's valid)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worktree is invalid
+    pub fn validate(&self, name: &str) -> Result<()> {
+        let record = find_worktree_by_branch(&self.repo.root, name)?
+            .with_context(|| format!("Worktree not found: {name}"))?;
+
+        if record.is_prunable {
+            bail!("Worktree '{name}' is invalid");
+        }
+
+        if !record.path.exists() {
+            bail!("Worktree '{name}' path does not exist");
+        }
+
+        Ok(())
+    }
+
+    /// Get the HEAD commit information for the main repository
+    ///
+    /// Returns (`branch_name`, `short_commit_hash`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HEAD cannot be read
+    pub fn head_info(&self) -> Result<(String, String)> {
+        let branch = git_output(&self.repo.root, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .context("Failed to get HEAD")?;
+        let short = git_output(&self.repo.root, &["rev-parse", "--short", "HEAD"])
+            .context("Failed to get HEAD commit")?;
+
+        let branch_name = if branch == "HEAD" {
+            "HEAD (detached)".to_string()
+        } else {
+            branch
+        };
+
+        Ok((branch_name, short))
+    }
+
+    /// Get the HEAD commit information for an existing worktree
+    ///
+    /// Returns (`branch_name`, `short_commit_hash`) if the worktree exists and has a valid HEAD
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worktree or its HEAD cannot be read
+    pub fn worktree_head_info(&self, name: &str) -> Result<(String, String)> {
+        let record = find_worktree_by_branch(&self.repo.root, name)?
+            .with_context(|| format!("Worktree not found: {name}"))?;
+
+        let branch = git_output(&record.path, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .context("Failed to get worktree HEAD")?;
+        let short = git_output(&record.path, &["rev-parse", "--short", "HEAD"])
+            .context("Failed to get worktree HEAD commit")?;
+
+        let branch_name = if branch == "HEAD" {
+            "HEAD (detached)".to_string()
+        } else {
+            branch
+        };
+
+        Ok((branch_name, short))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WorktreeRecord {
+    path: PathBuf,
+    branch: Option<String>,
+    is_locked: bool,
+    is_prunable: bool,
+}
+
+fn list_worktrees(repo_root: &Path) -> Result<Vec<WorktreeRecord>> {
+    let output = git_output(repo_root, &["worktree", "list", "--porcelain"])
+        .context("Failed to list worktrees")?;
+
+    let mut records = Vec::new();
+    let mut current: Option<WorktreeRecord> = None;
+
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if let Some(record) = current.take() {
+                records.push(record);
+            }
+            current = Some(WorktreeRecord {
+                path: PathBuf::from(path.trim()),
+                branch: None,
+                is_locked: false,
+                is_prunable: false,
+            });
+            continue;
+        }
+
+        let Some(record) = current.as_mut() else {
+            continue;
+        };
+
+        if let Some(branch) = line.strip_prefix("branch ") {
+            record.branch = Some(branch.trim().to_string());
+            continue;
+        }
+
+        if line.starts_with("locked") {
+            record.is_locked = true;
+            continue;
+        }
+
+        if line.starts_with("prunable") {
+            record.is_prunable = true;
+        }
+    }
+
+    if let Some(record) = current.take() {
+        records.push(record);
+    }
+
+    Ok(records)
+}
+
+fn find_worktree_by_branch(repo_root: &Path, name: &str) -> Result<Option<WorktreeRecord>> {
+    let records = list_worktrees(repo_root)?;
+    let target = format!("refs/heads/{name}");
+    Ok(records
+        .into_iter()
+        .find(|record| record.branch.as_deref() == Some(target.as_str())))
+}
+
+/// Information about a worktree
+#[derive(Debug, Clone)]
+pub struct Info {
+    /// Name of the worktree (usually branch name)
+    pub name: String,
+    /// Path to the worktree directory
+    pub path: PathBuf,
+    /// Whether the worktree is locked
+    pub is_locked: bool,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,13 @@
 //! Tenex allows you to run multiple AI agents in parallel, each in isolated
 //! git worktrees, with a TUI for managing and monitoring them.
 
+mod command;
+
 pub mod agent;
 pub mod app;
 pub mod config;
 pub mod git;
+pub mod paths;
 pub mod prompts;
 pub mod tmux;
 pub mod ui;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,63 @@
+//! Platform-specific filesystem path helpers.
+
+use std::path::PathBuf;
+
+/// Path to Tenex's debug log file.
+///
+/// This is located in the OS temp directory.
+#[must_use]
+pub fn log_path() -> PathBuf {
+    std::env::temp_dir().join("tenex.log")
+}
+
+/// Locate the user's home directory without pulling in external crates.
+#[must_use]
+pub fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(home) = std::env::var_os("USERPROFILE") {
+            return Some(PathBuf::from(home));
+        }
+
+        let drive = std::env::var_os("HOMEDRIVE");
+        let path = std::env::var_os("HOMEPATH");
+        if let (Some(drive), Some(path)) = (drive, path) {
+            let mut combined = PathBuf::from(drive);
+            combined.push(path);
+            return Some(combined);
+        }
+
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+}
+
+/// Resolve the local application data directory for the current platform.
+#[must_use]
+pub fn data_local_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        std::env::var_os("LOCALAPPDATA")
+            .or_else(|| std::env::var_os("APPDATA"))
+            .map(PathBuf::from)
+    }
+
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .or_else(|| {
+                home_dir().map(|home| {
+                    if cfg!(target_os = "macos") {
+                        home.join("Library").join("Application Support")
+                    } else {
+                        home.join(".local").join("share")
+                    }
+                })
+            })
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -8,6 +8,7 @@ use semver::Version;
 use serde::Deserialize;
 use std::process::Command;
 use std::time::Duration;
+use ureq::Agent;
 
 /// Information about an available update.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,29 +46,31 @@ pub fn check_for_update() -> Result<Option<UpdateInfo>> {
 
 /// Internal implementation that allows injecting the URL and current version for testing.
 fn check_for_update_impl(url: &str, current_version: &Version) -> Result<Option<UpdateInfo>> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(3))
-        .build()
-        .context("Failed to build HTTP client")?;
+    let builder = ureq::config::Config::builder().timeout_global(Some(Duration::from_secs(3)));
+    #[cfg(windows)]
+    let builder = builder.tls_config(
+        ureq::tls::TlsConfig::builder()
+            .provider(ureq::tls::TlsProvider::NativeTls)
+            .build(),
+    );
+    let agent: Agent = builder.build().new_agent();
+    let user_agent = format!("tenex/{current_version}");
 
-    let response = client
-        .get(url)
-        .header(
-            reqwest::header::USER_AGENT,
-            format!("tenex/{current_version}"),
-        )
-        .send()
-        .context("Failed to query crates.io for Tenex updates")?;
-
-    let status = response.status();
-    if !status.is_success() {
-        return Err(anyhow!(
-            "crates.io update check failed with status {status}"
-        ));
-    }
+    let response = match agent.get(url).header("User-Agent", user_agent).call() {
+        Ok(response) => response,
+        Err(ureq::Error::StatusCode(status)) => {
+            return Err(anyhow!(
+                "crates.io update check failed with status {status}"
+            ));
+        }
+        Err(err) => {
+            return Err(anyhow!(err)).context("Failed to query crates.io for Tenex updates");
+        }
+    };
 
     let body: CratesIoResponse = response
-        .json()
+        .into_body()
+        .read_json()
         .context("Failed to deserialize crates.io response")?;
 
     let latest_version = Version::parse(&body.krate.max_version)

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -68,15 +68,17 @@ fn test_cli_reset_force() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_log_file_cleared_on_startup() -> Result<(), Box<dyn std::error::Error>> {
     use std::fs;
-    use std::path::Path;
 
-    let log_path = Path::new("/tmp/tenex.log");
+    let log_path = tenex::paths::log_path();
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
 
     // Write some content to the log file to simulate previous session logs
-    fs::write(log_path, "previous session log content\nmore log lines\n")?;
+    fs::write(&log_path, "previous session log content\nmore log lines\n")?;
 
     // Verify the file has content
-    let content_before = fs::read_to_string(log_path)?;
+    let content_before = fs::read_to_string(&log_path)?;
     assert!(
         !content_before.is_empty(),
         "Log file should have content before test"
@@ -87,7 +89,7 @@ fn test_log_file_cleared_on_startup() -> Result<(), Box<dyn std::error::Error>> 
     assert!(output.status.success());
 
     // Verify the log file was cleared
-    let content_after = fs::read_to_string(log_path)?;
+    let content_after = fs::read_to_string(&log_path)?;
     assert!(
         content_after.is_empty(),
         "Log file should be empty after tenex startup, but contained: {content_after}"

--- a/tests/common/helpers.rs
+++ b/tests/common/helpers.rs
@@ -1,6 +1,30 @@
 //! Helper functions for test setup and common operations
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Create a `git` command with hook-related environment variables removed.
+///
+/// Git hooks can set variables like `GIT_DIR` which override repository discovery and ignore
+/// `current_dir`. This ensures `git` operations in tests use the temporary repositories created
+/// by the fixtures.
+#[must_use]
+pub fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_NAMESPACE",
+        "GIT_PREFIX",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
 
 /// Check if tmux is available on the system
 pub fn tmux_available() -> bool {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,4 +6,4 @@ pub mod helpers;
 
 pub use agent_factory::create_child_agent;
 pub use fixture::TestFixture;
-pub use helpers::{DirGuard, assert_paths_eq, skip_if_no_tmux};
+pub use helpers::{DirGuard, assert_paths_eq, git_command, skip_if_no_tmux};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(windows, allow(missing_docs))]
+#![cfg(not(windows))]
+
 //! Integration tests for CLI commands
 //!
 //! These tests require:

--- a/tests/integration/actions.rs
+++ b/tests/integration/actions.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for Actions handler with real operations
 
 use crate::common::{TestFixture, skip_if_no_tmux};

--- a/tests/integration/agent.rs
+++ b/tests/integration/agent.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for agent operations: listing, finding, status transitions
 
 use crate::common::TestFixture;

--- a/tests/integration/auto_connect.rs
+++ b/tests/integration/auto_connect.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Auto-connect to existing worktrees tests
 
 use crate::common::{DirGuard, TestFixture, assert_paths_eq, skip_if_no_tmux};

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -1,6 +1,8 @@
+#![cfg(not(windows))]
+
 //! Tests for git worktree operations
 
-use crate::common::{DirGuard, TestFixture};
+use crate::common::{DirGuard, TestFixture, git_command};
 use tenex::agent::{Agent, Storage};
 use tenex::app::{Actions, Settings};
 use tenex::config::Action;
@@ -157,11 +159,11 @@ fn test_execute_rebase_with_valid_agent() -> Result<(), Box<dyn std::error::Erro
 
     // Make a commit on the feature branch
     std::fs::write(worktree_path.join("test.txt"), "test content")?;
-    std::process::Command::new("git")
+    git_command()
         .args(["add", "test.txt"])
         .current_dir(&worktree_path)
         .output()?;
-    std::process::Command::new("git")
+    git_command()
         .args(["commit", "-m", "Test commit"])
         .current_dir(&worktree_path)
         .output()?;
@@ -215,11 +217,11 @@ fn test_execute_merge_with_valid_agent() -> Result<(), Box<dyn std::error::Error
 
     // Make a commit on the feature branch
     std::fs::write(worktree_path.join("feature.txt"), "feature content")?;
-    std::process::Command::new("git")
+    git_command()
         .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
         .output()?;
-    std::process::Command::new("git")
+    git_command()
         .args(["commit", "-m", "Feature commit"])
         .current_dir(&worktree_path)
         .output()?;
@@ -551,22 +553,22 @@ fn test_execute_rebase_with_conflict() -> Result<(), Box<dyn std::error::Error>>
 
     // Create a file on the feature branch
     std::fs::write(worktree_path.join("conflict.txt"), "feature content")?;
-    std::process::Command::new("git")
+    git_command()
         .args(["add", "conflict.txt"])
         .current_dir(&worktree_path)
         .output()?;
-    std::process::Command::new("git")
+    git_command()
         .args(["commit", "-m", "Feature commit"])
         .current_dir(&worktree_path)
         .output()?;
 
     // Now create a conflicting commit on master
     std::fs::write(fixture.repo_path.join("conflict.txt"), "master content")?;
-    std::process::Command::new("git")
+    git_command()
         .args(["add", "conflict.txt"])
         .current_dir(&fixture.repo_path)
         .output()?;
-    std::process::Command::new("git")
+    git_command()
         .args(["commit", "-m", "Master commit"])
         .current_dir(&fixture.repo_path)
         .output()?;
@@ -623,11 +625,11 @@ fn test_execute_merge_with_conflict() -> Result<(), Box<dyn std::error::Error>> 
 
     // First, create a commit on master with a file that will conflict
     std::fs::write(fixture.repo_path.join("shared.txt"), "initial")?;
-    std::process::Command::new("git")
+    git_command()
         .args(["add", "shared.txt"])
         .current_dir(&fixture.repo_path)
         .output()?;
-    std::process::Command::new("git")
+    git_command()
         .args(["commit", "-m", "Initial shared file"])
         .current_dir(&fixture.repo_path)
         .output()?;
@@ -641,22 +643,22 @@ fn test_execute_merge_with_conflict() -> Result<(), Box<dyn std::error::Error>> 
 
     // Modify the file on the feature branch
     std::fs::write(worktree_path.join("shared.txt"), "feature content")?;
-    std::process::Command::new("git")
+    git_command()
         .args(["add", "shared.txt"])
         .current_dir(&worktree_path)
         .output()?;
-    std::process::Command::new("git")
+    git_command()
         .args(["commit", "-m", "Feature changes to shared"])
         .current_dir(&worktree_path)
         .output()?;
 
     // Now create a conflicting modification on master
     std::fs::write(fixture.repo_path.join("shared.txt"), "master content")?;
-    std::process::Command::new("git")
+    git_command()
         .args(["add", "shared.txt"])
         .current_dir(&fixture.repo_path)
         .output()?;
-    std::process::Command::new("git")
+    git_command()
         .args(["commit", "-m", "Master changes to shared"])
         .current_dir(&fixture.repo_path)
         .output()?;

--- a/tests/integration/hierarchy.rs
+++ b/tests/integration/hierarchy.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for nested agent hierarchy and window index tracking
 
 use std::path::PathBuf;

--- a/tests/integration/persistence.rs
+++ b/tests/integration/persistence.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for storage persistence
 
 use crate::common::TestFixture;

--- a/tests/integration/review.rs
+++ b/tests/integration/review.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for [R] review agent functionality
 
 use crate::common::{TestFixture, skip_if_no_tmux};

--- a/tests/integration/synthesis.rs
+++ b/tests/integration/synthesis.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for synthesis functionality
 
 use crate::common::{DirGuard, TestFixture, skip_if_no_tmux};

--- a/tests/integration/tmux.rs
+++ b/tests/integration/tmux.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for tmux session operations and capture functions
 
 use crate::common::{TestFixture, skip_if_no_tmux};
@@ -18,7 +20,8 @@ fn test_tmux_session_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
     assert!(!manager.exists(&session_name));
 
     // Create session with a command that stays alive
-    let result = manager.create(&session_name, &fixture.worktree_path(), Some("sleep 10"));
+    let command = vec!["sleep".to_string(), "10".to_string()];
+    let result = manager.create(&session_name, &fixture.worktree_path(), Some(&command));
     assert!(result.is_ok());
 
     // Give tmux time to start
@@ -77,7 +80,8 @@ fn test_tmux_capture_pane() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a session that stays alive
     let _ = manager.kill(&session_name);
-    manager.create(&session_name, &fixture.worktree_path(), Some("sleep 60"))?;
+    let command = vec!["sleep".to_string(), "60".to_string()];
+    manager.create(&session_name, &fixture.worktree_path(), Some(&command))?;
 
     std::thread::sleep(std::time::Duration::from_millis(300));
 
@@ -111,7 +115,8 @@ fn test_tmux_capture_pane_with_history() -> Result<(), Box<dyn std::error::Error
 
     // Create a session that stays alive
     let _ = manager.kill(&session_name);
-    manager.create(&session_name, &fixture.worktree_path(), Some("sleep 60"))?;
+    let command = vec!["sleep".to_string(), "60".to_string()];
+    manager.create(&session_name, &fixture.worktree_path(), Some(&command))?;
 
     std::thread::sleep(std::time::Duration::from_millis(300));
 
@@ -145,7 +150,8 @@ fn test_tmux_capture_full_history() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a session that stays alive
     let _ = manager.kill(&session_name);
-    manager.create(&session_name, &fixture.worktree_path(), Some("sleep 60"))?;
+    let command = vec!["sleep".to_string(), "60".to_string()];
+    manager.create(&session_name, &fixture.worktree_path(), Some(&command))?;
 
     std::thread::sleep(std::time::Duration::from_millis(300));
 
@@ -260,11 +266,12 @@ fn test_tmux_window_operations() -> Result<(), Box<dyn std::error::Error>> {
     std::thread::sleep(std::time::Duration::from_millis(200));
 
     // Create a window
+    let window_command = vec!["sleep".to_string(), "60".to_string()];
     let window_result = manager.create_window(
         &session_name,
         "test-window",
         &fixture.worktree_path(),
-        Some("echo hello"),
+        Some(&window_command),
     );
     assert!(window_result.is_ok());
 
@@ -295,7 +302,8 @@ fn test_tmux_capture_tail() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create session with output
     let _ = manager.kill(&session_name);
-    manager.create(&session_name, &fixture.worktree_path(), Some("sleep 60"))?;
+    let command = vec!["sleep".to_string(), "60".to_string()];
+    manager.create(&session_name, &fixture.worktree_path(), Some(&command))?;
     std::thread::sleep(std::time::Duration::from_millis(300));
 
     // Capture tail
@@ -378,7 +386,8 @@ fn test_tmux_pane_current_command() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create session with a specific command
     let _ = manager.kill(&session_name);
-    manager.create(&session_name, &fixture.worktree_path(), Some("sleep 60"))?;
+    let command = vec!["sleep".to_string(), "60".to_string()];
+    manager.create(&session_name, &fixture.worktree_path(), Some(&command))?;
     std::thread::sleep(std::time::Duration::from_millis(300));
 
     // Get current command

--- a/tests/integration/workflow.rs
+++ b/tests/integration/workflow.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Tests for full CLI workflow, agent creation, and kill success paths
 
 use crate::common::{TestFixture, skip_if_no_tmux};
@@ -27,7 +29,8 @@ fn test_agent_creation_workflow() -> Result<(), Box<dyn std::error::Error>> {
     worktree_mgr.create_with_new_branch(&worktree_path, &branch)?;
 
     // Create tmux session with a command that stays alive
-    manager.create(&session_name, &worktree_path, Some("sleep 10"))?;
+    let command = vec!["sleep".to_string(), "10".to_string()];
+    manager.create(&session_name, &worktree_path, Some(&command))?;
 
     std::thread::sleep(std::time::Duration::from_millis(100));
 
@@ -182,7 +185,8 @@ fn test_full_cli_workflow() -> Result<(), Box<dyn std::error::Error>> {
     let worktree_mgr = tenex::git::WorktreeManager::new(&repo);
     worktree_mgr.create_with_new_branch(&worktree_path, &branch)?;
 
-    manager.create(&session_name, &worktree_path, Some("sleep 60"))?;
+    let command = vec!["sleep".to_string(), "60".to_string()];
+    manager.create(&session_name, &worktree_path, Some(&command))?;
 
     std::thread::sleep(std::time::Duration::from_millis(100));
 

--- a/tests/integration/worktree_conflict.rs
+++ b/tests/integration/worktree_conflict.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 //! Worktree conflict detection and resolution tests
 
 use std::fs;


### PR DESCRIPTION
## Summary
- Add Windows git CLI backend (branch/diff/worktree) so installs don’t require libgit2.
- Use native TLS for update checks on Windows to avoid rustls feature panics.
- Improve tmux handling on Windows (MSYS2 path support, TENEX_TMUX_BIN docs) and suppress duplicate keypresses from key-release events.
- Speed up CI with cancellation, lighter linting, and push-only coverage/release artifacts.

## Windows UX
- Uses `git` CLI on Windows (no libgit2).
- Update checks use Native TLS.
- `TENEX_TMUX_BIN` can pin MSYS2 tmux without PATH edits.
- Integration tests are skipped on Windows (tmux dependency).

## CI
- Concurrency cancellation to reduce queue time.
- Lint runs fmt+clippy only; coverage runs on push.
- Release artifacts build on Linux pushes only.

## Tests
- `pre-commit run --all-files`
- CI (Linux/macOS/Windows)
