### PR TITLE
ci: run coverage checks on pull requests instead of push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
   coverage:
     name: Coverage (ubuntu-latest)
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Coverage checks now run on pull requests instead of on merge to main
- This provides earlier feedback during code review

## Test plan
- [ ] Verify coverage job runs on PR creation
- [ ] Verify coverage job no longer runs on push to main