### PR TITLE
Mouse wheel scrolls preview/diff

### DIFF
--- a/src/app/state/ui.rs
+++ b/src/app/state/ui.rs
@@ -6,6 +6,10 @@ use std::path::PathBuf;
 
 /// UI-related state for the application
 #[derive(Debug, Default)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "UiState stores a handful of independent rendering/behavior flags"
+)]
 pub struct UiState {
     /// Scroll offset for the agent list (index of first visible agent)
     pub agent_list_scroll: usize,
@@ -29,6 +33,12 @@ pub struct UiState {
     /// Whether preview should auto-scroll to bottom on content updates
     /// Set to false when user manually scrolls up, true when they scroll to bottom
     pub preview_follow: bool,
+
+    /// Whether the current preview buffer represents the full scrollback history.
+    ///
+    /// Used to keep scroll position stable when switching between a short tail
+    /// buffer (following) and full history (manual scrolling).
+    pub preview_using_full_history: bool,
 
     /// Cached preview content
     pub preview_content: String,
@@ -97,6 +107,7 @@ impl UiState {
             diff_visual_anchor: None,
             help_scroll: 0,
             preview_follow: true,
+            preview_using_full_history: false,
             preview_content: String::new(),
             preview_cursor_position: None,
             preview_pane_size: None,
@@ -155,6 +166,7 @@ impl UiState {
         // Preview: set to max so render functions clamp to bottom of content
         self.preview_scroll = usize::MAX;
         self.preview_follow = true;
+        self.preview_using_full_history = false;
         // Diff: set to 0 to show from top
         self.diff_scroll = 0;
         self.diff_cursor = 0;

--- a/tests/integration/actions.rs
+++ b/tests/integration/actions.rs
@@ -1,6 +1,6 @@
 //! Tests for Actions handler with real operations
 
-use crate::common::{TestFixture, skip_if_no_mux};
+use crate::common::{DirGuard, TestFixture, skip_if_no_mux};
 use tenex::mux::SessionManager;
 
 #[test]
@@ -146,6 +146,117 @@ fn test_actions_update_preview_integration() -> Result<(), Box<dyn std::error::E
 
     // Cleanup
     let manager = SessionManager::new();
+    for agent in app.data.storage.iter() {
+        let _ = manager.kill(&agent.mux_session);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_actions_update_preview_full_history_when_scrolled() -> Result<(), Box<dyn std::error::Error>>
+{
+    if skip_if_no_mux() {
+        return Ok(());
+    }
+
+    let fixture = TestFixture::new("actions_preview_scroll")?;
+    let mut config = fixture.config();
+    // Use an interactive shell so we can generate lots of output reliably.
+    config.default_program = "sh".to_string();
+    let storage = TestFixture::create_storage();
+
+    // Change to repo directory for the test (DirGuard restores on drop).
+    let _dir_guard = DirGuard::new()?;
+    std::env::set_current_dir(&fixture.repo_path)?;
+
+    let mut app = tenex::App::new(config, storage, tenex::app::Settings::default(), false);
+    // Ensure a stable "visible height" for scroll calculations and resize new sessions.
+    app.set_preview_dimensions(80, 20);
+
+    let handler = tenex::app::Actions::new();
+    let manager = SessionManager::new();
+
+    // Create an agent.
+    let next = handler.create_agent(&mut app.data, "preview-scroll-test", None)?;
+    app.apply_mode(next);
+    app.select_next();
+
+    let session = app
+        .selected_agent()
+        .ok_or_else(|| anyhow::anyhow!("No agent selected"))?
+        .mux_session
+        .clone();
+
+    // Generate >300 lines so the tail capture excludes early lines.
+    manager.send_keys_and_submit(
+        &session,
+        "i=1; while [ $i -le 500 ]; do printf 'TENEX_SCROLL_TEST_LINE_%04d\\n' $i; i=$((i+1)); done",
+    )?;
+
+    // Wait for output to appear in the preview buffer.
+    let start = std::time::Instant::now();
+    loop {
+        handler.update_preview(&mut app)?;
+        if app
+            .data
+            .ui
+            .preview_content
+            .contains("TENEX_SCROLL_TEST_LINE_0500")
+        {
+            break;
+        }
+        if start.elapsed() > std::time::Duration::from_secs(5) {
+            return Err(anyhow::anyhow!("Timed out waiting for preview output").into());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    // While following, we should still be using a small tail window.
+    assert!(app.data.ui.preview_follow);
+    assert!(!app.data.ui.preview_using_full_history);
+    assert!(
+        !app.data
+            .ui
+            .preview_content
+            .contains("TENEX_SCROLL_TEST_LINE_0001"),
+        "Tail capture should not include earliest lines"
+    );
+
+    // Simulate user scrolling up (disables follow).
+    app.scroll_up(10);
+    assert!(!app.data.ui.preview_follow);
+
+    // Record distance from bottom in the tail buffer.
+    let old_line_count = app.data.ui.preview_content.lines().count();
+    let visible_height = app
+        .data
+        .ui
+        .preview_dimensions
+        .map_or(20, |(_, h)| usize::from(h));
+    let old_max = old_line_count.saturating_sub(visible_height);
+    let old_scroll = app.data.ui.preview_scroll.min(old_max);
+    let old_distance_from_bottom = old_max.saturating_sub(old_scroll);
+
+    // Updating the preview while scrolled should switch to full history and keep scroll stable.
+    handler.update_preview(&mut app)?;
+
+    assert!(app.data.ui.preview_using_full_history);
+    assert!(
+        app.data
+            .ui
+            .preview_content
+            .contains("TENEX_SCROLL_TEST_LINE_0001"),
+        "Full history capture should include earliest lines"
+    );
+
+    let new_line_count = app.data.ui.preview_content.lines().count();
+    let new_max = new_line_count.saturating_sub(visible_height);
+    let new_scroll = app.data.ui.preview_scroll.min(new_max);
+    let new_distance_from_bottom = new_max.saturating_sub(new_scroll);
+    assert_eq!(new_distance_from_bottom, old_distance_from_bottom);
+
+    // Cleanup
     for agent in app.data.storage.iter() {
         let _ = manager.kill(&agent.mux_session);
     }


### PR DESCRIPTION
## What

- Add mouse wheel scrolling for the content pane (preview/diff).
- When the user scrolls up (follow disabled), switch preview capture to full history to prevent jumpy scrolling from a moving tail window.
- Preserve scroll offset when switching tail → full history.
- Add an integration test covering the scrollback behavior.

## Why

Scrolling the preview should behave like a normal terminal: the wheel scrolls regardless of focus, and manual scrolling should be stable even while new output arrives.