### PR TITLE
agents: respawn sessions after restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ On first launch, Tenex checks if your terminal supports the Kitty keyboard proto
 If a newly-created agent flashes into existence and vanishes a few seconds later, it usually means the underlying agent process exited during startup (Tenex then prunes the agent because its mux session is gone).
 
 - Enable logs with `DEBUG=3 tenex` and inspect the log at `/tmp/tenex.log`.
-- Tenex isolates mux daemons per build by default, so stale daemons from older installs shouldn’t interfere after an upgrade.
-- To isolate mux state, start Tenex with an explicit socket: `TENEX_MUX_SOCKET=/tmp/tenex-mux.sock tenex`.
+- Tenex stores the mux socket name in `~/.tenex/state.json` so sessions can survive rebuilds/upgrades.
+- To force a fresh mux daemon, set an explicit socket: `TENEX_MUX_SOCKET=/tmp/tenex-mux.sock tenex`.
 
 ## License
 

--- a/src/action/agent.rs
+++ b/src/action/agent.rs
@@ -479,7 +479,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         assert!(matches!(
@@ -519,7 +518,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         root.collapsed = true;
@@ -531,7 +529,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,

--- a/src/action/diff.rs
+++ b/src/action/diff.rs
@@ -837,7 +837,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
         data.active_tab = Tab::Diff;
         set_diff_view_from_repo(&mut data, &repo)?;
@@ -878,7 +877,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
         data.active_tab = Tab::Diff;
         set_diff_view_from_repo(&mut data, &repo)?;
@@ -945,7 +943,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
         data.active_tab = Tab::Diff;
         set_diff_view_from_repo(&mut data, &repo)?;
@@ -974,7 +971,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
         DiffUndoAction.execute(DiffFocusedMode, &mut data)?;
         assert_eq!(data.ui.status_message.as_deref(), Some("Nothing to undo"));
@@ -1005,7 +1001,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
         data.active_tab = Tab::Diff;
         set_diff_view_from_repo(&mut data, &repo)?;
@@ -1036,7 +1031,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
         data.active_tab = Tab::Diff;
         set_diff_view_from_repo(&mut data, &repo)?;
@@ -1072,7 +1066,6 @@ mod tests {
             "claude".to_string(),
             "feature/root".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
         data.active_tab = Tab::Diff;
         set_diff_view_from_repo(&mut data, &repo)?;

--- a/src/action/git.rs
+++ b/src/action/git.rs
@@ -281,7 +281,6 @@ mod tests {
             "echo".to_string(),
             format!("tenex-action-git-test-{pid}/{title}"),
             PathBuf::from(format!("/tmp/tenex-action-git-test-{pid}/{title}")),
-            None,
         )
     }
 

--- a/src/action/misc.rs
+++ b/src/action/misc.rs
@@ -118,7 +118,6 @@ mod tests {
             "echo".to_string(),
             format!("tenex-action-misc-test-{pid}/{title}"),
             PathBuf::from(format!("/tmp/tenex-action-misc-test-{pid}/{title}")),
-            None,
         );
         agent.set_status(status);
         agent

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -738,7 +738,6 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         let root_session = root.mux_session.clone();
@@ -750,7 +749,6 @@ mod tests {
             "claude".to_string(),
             root_branch,
             root_worktree,
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,

--- a/src/action/navigation.rs
+++ b/src/action/navigation.rs
@@ -260,14 +260,12 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
         data.storage.add(Agent::new(
             "second".to_string(),
             "claude".to_string(),
             "tenex/second".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
     }
 

--- a/src/agent/storage.rs
+++ b/src/agent/storage.rs
@@ -156,6 +156,13 @@ pub struct Storage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instance_id: Option<String>,
 
+    /// Mux daemon socket name/path used by this Tenex instance.
+    ///
+    /// Tenex persists this value so agent sessions can survive restarts even if the Tenex binary
+    /// (and thus the default mux socket fingerprint) changes across upgrades or rebuilds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mux_socket: Option<String>,
+
     /// Custom state file path (if set, overrides default location)
     /// When None, uses `Config::state_path()`
     #[serde(skip)]
@@ -180,6 +187,7 @@ impl Storage {
             agents: Vec::new(),
             version: default_version(),
             instance_id: None,
+            mux_socket: None,
             state_path: None,
         }
     }
@@ -192,6 +200,7 @@ impl Storage {
             agents: Vec::new(),
             version: 1, // Can't call default_version() in const context
             instance_id: None,
+            mux_socket: None,
             state_path: Some(path),
         }
     }
@@ -688,7 +697,6 @@ mod tests {
             "claude".to_string(),
             format!("tenex/{title}"),
             PathBuf::from("/tmp/worktree"),
-            None,
         )
     }
 
@@ -886,7 +894,6 @@ mod tests {
             "claude".to_string(),
             parent.branch.clone(),
             parent.worktree_path.clone(),
-            None,
             ChildConfig {
                 parent_id: parent.id,
                 mux_session: parent.mux_session.clone(),
@@ -967,7 +974,6 @@ mod tests {
             "claude".to_string(),
             root.branch.clone(),
             root.worktree_path.clone(),
-            None,
             ChildConfig {
                 parent_id: child.id,
                 mux_session: root.mux_session.clone(),
@@ -1013,7 +1019,6 @@ mod tests {
             "claude".to_string(),
             root.branch.clone(),
             root.worktree_path.clone(),
-            None,
             ChildConfig {
                 parent_id: child1.id,
                 mux_session: root.mux_session.clone(),
@@ -1042,7 +1047,6 @@ mod tests {
             "claude".to_string(),
             root.branch.clone(),
             root.worktree_path.clone(),
-            None,
             ChildConfig {
                 parent_id: child.id,
                 mux_session: root.mux_session.clone(),
@@ -1143,7 +1147,6 @@ mod tests {
             "claude".to_string(),
             root.branch.clone(),
             root.worktree_path.clone(),
-            None,
             ChildConfig {
                 parent_id: child1.id,
                 mux_session: root.mux_session.clone(),

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -557,7 +557,6 @@ mod tests {
             "echo".to_string(),
             format!("tenex-app-data-test-{pid}/{title}"),
             PathBuf::from(format!("/tmp/tenex-app-data-test-{pid}/{title}")),
-            None,
         )
     }
 

--- a/src/app/handlers/agent_lifecycle.rs
+++ b/src/app/handlers/agent_lifecycle.rs
@@ -92,7 +92,6 @@ impl Actions {
             program.clone(),
             branch.to_string(),
             worktree_path.to_path_buf(),
-            prompt.map(String::from),
         );
         let session_prefix = app_data.storage.instance_session_prefix();
         agent.mux_session = format!("{session_prefix}{}", agent.short_id());
@@ -140,7 +139,6 @@ impl Actions {
                 program.clone(),
                 conflict.branch.clone(),
                 conflict.worktree_path.clone(),
-                None, // Root doesn't get the prompt
             );
             let session_prefix = app_data.storage.instance_session_prefix();
             root_agent.mux_session = format!("{session_prefix}{}", root_agent.short_id());
@@ -181,7 +179,6 @@ impl Actions {
                 program.clone(),
                 conflict.branch.clone(),
                 conflict.worktree_path.clone(),
-                conflict.prompt.clone(),
             );
             let session_prefix = app_data.storage.instance_session_prefix();
             agent.mux_session = format!("{session_prefix}{}", agent.short_id());
@@ -410,7 +407,6 @@ impl Actions {
             "terminal".to_string(),
             branch,
             worktree_path.clone(),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session.clone(),
@@ -510,7 +506,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp/nonexistent"),
-            None,
         ));
 
         // Enter confirming mode for kill
@@ -538,7 +533,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // Kill should work (session doesn't exist, but should not error)
@@ -558,7 +552,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         root.collapsed = false;
         let root_id = root.id;
@@ -571,7 +564,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,
@@ -601,7 +593,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         let root_session = root.mux_session.clone();
@@ -614,7 +605,6 @@ mod tests {
                 "claude".to_string(),
                 "muster/root".to_string(),
                 PathBuf::from("/tmp"),
-                None,
                 ChildConfig {
                     parent_id: root_id,
                     mux_session: root_session.clone(),
@@ -640,7 +630,6 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp/worktree"),
-            None,
         );
         root.collapsed = false;
         let root_id = root.id;
@@ -653,7 +642,6 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp/worktree"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,

--- a/src/app/handlers/broadcast.rs
+++ b/src/app/handlers/broadcast.rs
@@ -120,7 +120,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         let next = handler.broadcast_to_leaves(&mut app.data, "test message")?;
@@ -139,7 +138,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         root.collapsed = false;
         let root_id = root.id;
@@ -153,7 +151,6 @@ mod tests {
                 "claude".to_string(),
                 "muster/root".to_string(),
                 PathBuf::from("/tmp"),
-                None,
                 ChildConfig {
                     parent_id: root_id,
                     mux_session: root_session.clone(),

--- a/src/app/handlers/git_ops/merge.rs
+++ b/src/app/handlers/git_ops/merge.rs
@@ -234,7 +234,6 @@ impl Actions {
                 "terminal".to_string(),
                 branch,
                 worktree_path.to_path_buf(),
-                None,
                 ChildConfig {
                     parent_id: root_id,
                     mux_session: root_session.clone(),

--- a/src/app/handlers/git_ops/mod.rs
+++ b/src/app/handlers/git_ops/mod.rs
@@ -55,7 +55,6 @@ impl Actions {
             "terminal".to_string(),
             branch,
             worktree_path.clone(),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session.clone(),

--- a/src/app/handlers/git_ops/tests.rs
+++ b/src/app/handlers/git_ops/tests.rs
@@ -37,7 +37,6 @@ fn test_handle_push_with_agent() -> Result<(), Box<dyn std::error::Error>> {
         "claude".to_string(),
         "muster/test".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -59,7 +58,6 @@ fn test_push_branch_sets_confirm_mode() -> Result<(), Box<dyn std::error::Error>
         "claude".to_string(),
         "feature/pushable".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -104,7 +102,6 @@ fn test_rename_agent_sets_state_for_selected() -> Result<(), Box<dyn std::error:
         "claude".to_string(),
         "feature/rename-me".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -177,7 +174,6 @@ fn test_open_pr_flow_sets_confirm_for_unpushed() -> Result<(), Box<dyn std::erro
         "claude".to_string(),
         "feature/pr-agent".to_string(),
         temp_dir.path().to_path_buf(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -202,7 +198,6 @@ fn test_open_pr_in_browser_missing_gh_sets_error() -> Result<(), Box<dyn std::er
         "claude".to_string(),
         "feature/gh-less".to_string(),
         temp_dir.path().to_path_buf(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -234,7 +229,6 @@ fn test_push_flow_state_transitions() -> Result<(), Box<dyn std::error::Error>> 
         "claude".to_string(),
         "feature/test".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -262,7 +256,6 @@ fn test_rename_root_flow_state_transitions() -> Result<(), Box<dyn std::error::E
         "claude".to_string(),
         "tenex/test-agent".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -304,7 +297,6 @@ fn test_rename_subagent_flow_state_transitions() -> Result<(), Box<dyn std::erro
         "claude".to_string(),
         "tenex/root-agent".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     app.data.storage.add(root.clone());
 
@@ -314,7 +306,6 @@ fn test_rename_subagent_flow_state_transitions() -> Result<(), Box<dyn std::erro
         "claude".to_string(),
         "tenex/root-agent".to_string(),
         PathBuf::from("/tmp"),
-        None,
         crate::agent::ChildConfig {
             parent_id: root.id,
             mux_session: root.mux_session,
@@ -359,7 +350,6 @@ fn test_open_pr_flow_state_with_unpushed() -> Result<(), Box<dyn std::error::Err
         "claude".to_string(),
         "feature/test".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -390,7 +380,6 @@ fn test_open_pr_flow_state_no_unpushed() -> Result<(), Box<dyn std::error::Error
         "claude".to_string(),
         "feature/test".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -420,7 +409,6 @@ fn test_execute_push_and_open_pr_handles_failed_push() -> Result<(), Box<dyn std
         "claude".to_string(),
         "feature/failing-push".to_string(),
         temp_dir.path().to_path_buf(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -475,7 +463,6 @@ fn test_handle_rename_with_root_agent() -> Result<(), Box<dyn std::error::Error>
         "claude".to_string(),
         "tenex/test-agent".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -503,7 +490,6 @@ fn test_handle_rename_with_subagent() -> Result<(), Box<dyn std::error::Error>> 
         "claude".to_string(),
         "tenex/root".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let root_id = root.id;
     app.data.storage.add(root.clone());
@@ -514,7 +500,6 @@ fn test_handle_rename_with_subagent() -> Result<(), Box<dyn std::error::Error>> 
         "claude".to_string(),
         "tenex/root".to_string(),
         PathBuf::from("/tmp"),
-        None,
         crate::agent::ChildConfig {
             parent_id: root_id,
             mux_session: root.mux_session,
@@ -645,7 +630,6 @@ fn test_open_pr_flow_with_agent() -> Result<(), Box<dyn std::error::Error>> {
         "claude".to_string(),
         "tenex/test".to_string(),
         temp_dir.path().to_path_buf(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -669,7 +653,6 @@ fn test_push_flow_with_agent() -> Result<(), Box<dyn std::error::Error>> {
         "claude".to_string(),
         "tenex/test".to_string(),
         PathBuf::from("/tmp"),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);

--- a/src/app/handlers/mod.rs
+++ b/src/app/handlers/mod.rs
@@ -219,7 +219,6 @@ mod tests {
                 "claude".to_string(),
                 format!("muster/agent{i}"),
                 PathBuf::from("/tmp"),
-                None,
             ));
         }
 
@@ -294,7 +293,6 @@ mod tests {
             "claude".to_string(),
             "muster/running".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         agent.set_status(Status::Running);
         app.data.storage.add(agent);
@@ -324,7 +322,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // Kill should enter confirming mode
@@ -372,7 +369,6 @@ mod tests {
                 "claude".to_string(),
                 format!("muster/agent{i}"),
                 PathBuf::from("/tmp"),
-                None,
             ));
         }
 
@@ -404,7 +400,6 @@ mod tests {
             "claude".to_string(),
             "test-session".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // FocusPreview should enter PreviewFocused mode
@@ -442,7 +437,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // Should not error when agent has no children
@@ -474,7 +468,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let agent_id = agent.id;
         app.data.storage.add(agent);
@@ -510,7 +503,6 @@ mod tests {
             "claude".to_string(),
             "tenex/parent".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let parent_id = parent.id;
         app.data.storage.add(parent);
@@ -521,7 +513,6 @@ mod tests {
             "claude".to_string(),
             "tenex/child".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         child.parent_id = Some(parent_id);
         app.data.storage.add(child);
@@ -551,7 +542,6 @@ mod tests {
             "claude".to_string(),
             "tenex/parent".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // No children - should show error modal, not enter confirming mode
@@ -594,7 +584,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         handler.handle_action(&mut app, Action::Broadcast)?;
@@ -798,7 +787,6 @@ mod tests {
             "claude".to_string(),
             "tenex/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // With agent selected - should enter TerminalPrompt mode
@@ -820,7 +808,6 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // Counter starts at 0
@@ -849,7 +836,6 @@ mod tests {
             "terminal".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: uuid::Uuid::new_v4(),
                 mux_session: "test-session".to_string(),
@@ -884,7 +870,6 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // 4. With agent - [T] enters prompt mode
@@ -946,7 +931,6 @@ mod tests {
             "claude".to_string(),
             "tenex/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         handler.handle_action(&mut app, Action::Kill)?;
@@ -981,7 +965,6 @@ mod tests {
             "claude".to_string(),
             "tenex/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         agent.status = Status::Running;
         app.data.storage.add(agent);
@@ -1029,7 +1012,6 @@ mod tests {
             "claude".to_string(),
             "tenex/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         handler.handle_action(&mut app, Action::Synthesize)?;
@@ -1060,7 +1042,6 @@ mod tests {
             "claude".to_string(),
             "tenex/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         handler.handle_action(&mut app, Action::Broadcast)?;
@@ -1090,7 +1071,6 @@ mod tests {
             "claude".to_string(),
             "tenex/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         handler.handle_action(&mut app, Action::SpawnTerminalPrompted)?;

--- a/src/app/handlers/preview.rs
+++ b/src/app/handlers/preview.rs
@@ -238,7 +238,6 @@ mod tests {
             "claude".to_string(),
             "nonexistent-session".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         handler.update_preview(&mut app)?;
@@ -257,7 +256,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/nonexistent/path"),
-            None,
         ));
 
         handler.update_diff(&mut app)?;
@@ -281,7 +279,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
 
         handler.update_diff(&mut app)?;
@@ -324,14 +321,12 @@ mod tests {
             "claude".to_string(),
             "muster/a".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
         app.data.storage.add(Agent::new(
             "b".to_string(),
             "claude".to_string(),
             "muster/b".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
 
         app.data.active_tab = crate::app::Tab::Diff;
@@ -362,7 +357,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         root.collapsed = false;
         let root_id = root.id;
@@ -374,7 +368,6 @@ mod tests {
             "claude".to_string(),
             "muster/child".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,
@@ -429,7 +422,6 @@ mod tests {
             "claude".to_string(),
             "muster/a".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
 
         app.data.active_tab = crate::app::Tab::Preview;
@@ -461,7 +453,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/nonexistent/path"),
-            None,
         ));
 
         handler.update_diff_digest(&mut app)?;
@@ -505,7 +496,6 @@ mod tests {
             "claude".to_string(),
             "muster/a".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
 
         app.data.active_tab = crate::app::Tab::Preview;
@@ -551,7 +541,6 @@ mod tests {
             "claude".to_string(),
             "muster/a".to_string(),
             temp_dir.path().to_path_buf(),
-            None,
         ));
 
         // Viewing diff marks the current hash as "seen".

--- a/src/app/handlers/swarm.rs
+++ b/src/app/handlers/swarm.rs
@@ -116,7 +116,6 @@ impl Actions {
             program.clone(),
             branch.clone(),
             worktree_path.clone(),
-            None,
         );
         let session_prefix = app_data.storage.instance_session_prefix();
         root_agent.mux_session = format!("{session_prefix}{}", root_agent.short_id());
@@ -243,7 +242,6 @@ impl Actions {
             program.to_string(),
             config.branch.clone(),
             config.worktree_path.clone(),
-            child_prompt.map(String::from),
             ChildConfig {
                 parent_id: config.parent_agent_id,
                 mux_session: config.root_session.clone(),
@@ -351,7 +349,6 @@ impl Actions {
                 program.clone(),
                 branch.clone(),
                 worktree_path.clone(),
-                Some(review_prompt.clone()),
                 ChildConfig {
                     parent_id,
                     mux_session: root_session.clone(),
@@ -567,7 +564,6 @@ mod tests {
             "echo".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         app.data.storage.add(root);
@@ -607,7 +603,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // Should set error when agent has no children
@@ -650,7 +645,6 @@ mod tests {
             "claude".to_string(),
             "muster/test".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let agent_id = agent.id;
         app.data.storage.add(agent);
@@ -675,7 +669,6 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         root.collapsed = false;
         let root_id = root.id;
@@ -688,7 +681,6 @@ mod tests {
             "claude".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session.clone(),
@@ -703,7 +695,6 @@ mod tests {
             "terminal".to_string(),
             "tenex/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,

--- a/src/app/handlers/window.rs
+++ b/src/app/handlers/window.rs
@@ -140,7 +140,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
 
         // Should not panic when resizing non-existent sessions
@@ -162,7 +161,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         let root_session = root.mux_session.clone();
@@ -174,7 +172,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,
@@ -196,7 +193,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         app.data.storage.add(root);
@@ -215,7 +211,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         let root_session = root.mux_session.clone();
@@ -227,7 +222,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session.clone(),
@@ -242,7 +236,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,
@@ -273,7 +266,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         let root_session = root.mux_session.clone();
@@ -285,7 +277,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,
@@ -316,7 +307,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let root_id = root.id;
         let root_session = root.mux_session.clone();
@@ -328,7 +318,6 @@ mod tests {
             "claude".to_string(),
             "muster/root".to_string(),
             PathBuf::from("/tmp"),
-            None,
             ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session,

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -10,7 +10,6 @@ fn create_test_agent(title: &str) -> Agent {
         "claude".to_string(),
         format!("tenex/{title}"),
         PathBuf::from("/tmp/worktree"),
-        None,
     )
 }
 

--- a/src/mux/discovery.rs
+++ b/src/mux/discovery.rs
@@ -1,0 +1,229 @@
+//! Mux daemon socket discovery helpers.
+//!
+//! Tenex can run multiple mux daemons (for example across rebuilds/upgrades when the default
+//! socket fingerprint changes). This module helps locate the daemon that owns a set of stored
+//! sessions so agents can survive restarts.
+
+use super::endpoint::socket_endpoint_from_value;
+use super::ipc;
+use super::protocol::{MuxRequest, MuxResponse};
+use interprocess::local_socket::Stream;
+use interprocess::local_socket::traits::Stream as StreamTrait;
+use std::collections::{HashMap, HashSet};
+
+/// Attempt to find a running mux daemon socket that contains at least one of the requested
+/// session names.
+///
+/// `preferred_socket` is checked first when provided.
+#[must_use]
+pub fn discover_socket_for_sessions<S: std::hash::BuildHasher>(
+    wanted_sessions: &HashSet<String, S>,
+    preferred_socket: Option<&str>,
+) -> Option<String> {
+    if wanted_sessions.is_empty() {
+        return None;
+    }
+
+    let mut candidates = Vec::new();
+    if let Some(socket) = preferred_socket
+        .map(str::trim)
+        .filter(|socket| !socket.is_empty())
+    {
+        candidates.push(socket.to_string());
+    }
+
+    if let Ok(default_socket) = super::socket_display() {
+        candidates.push(default_socket);
+    }
+
+    candidates.extend(running_mux_sockets());
+
+    let mut seen = HashSet::new();
+    candidates.retain(|candidate| seen.insert(candidate.clone()));
+
+    let mut best: Option<(usize, String)> = None;
+    for candidate in candidates {
+        let Some(matches) = probe_session_matches(&candidate, wanted_sessions) else {
+            continue;
+        };
+        if matches == 0 {
+            continue;
+        }
+
+        match &best {
+            None => best = Some((matches, candidate)),
+            Some((best_matches, _)) if matches > *best_matches => {
+                best = Some((matches, candidate));
+            }
+            _ => {}
+        }
+    }
+
+    best.map(|(_, socket)| socket)
+}
+
+fn probe_session_matches<S: std::hash::BuildHasher>(
+    socket: &str,
+    wanted_sessions: &HashSet<String, S>,
+) -> Option<usize> {
+    let endpoint = socket_endpoint_from_value(socket).ok()?;
+    let mut stream = Stream::connect(endpoint.name).ok()?;
+
+    ipc::write_json(&mut stream, &MuxRequest::ListSessions).ok()?;
+    let response: MuxResponse = ipc::read_json(&mut stream).ok()?;
+
+    let MuxResponse::Sessions { sessions } = response else {
+        return None;
+    };
+
+    Some(
+        sessions
+            .into_iter()
+            .filter(|session| wanted_sessions.contains(&session.name))
+            .count(),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn running_mux_sockets() -> Vec<String> {
+    let mut sockets = HashSet::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(pid) = file_name.to_str() else {
+            continue;
+        };
+        if pid.is_empty() || !pid.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+
+        let base = entry.path();
+        let Ok(cmdline) = std::fs::read(base.join("cmdline")) else {
+            continue;
+        };
+        if !cmdline_contains_muxd(&cmdline) {
+            continue;
+        }
+
+        let Ok(environ) = std::fs::read(base.join("environ")) else {
+            continue;
+        };
+
+        if let Some(value) = parse_environ(&environ).get("TENEX_MUX_SOCKET") {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                let _ = sockets.insert(trimmed.to_string());
+            }
+        }
+    }
+
+    sockets.into_iter().collect()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn running_mux_sockets() -> Vec<String> {
+    Vec::new()
+}
+
+fn cmdline_contains_muxd(cmdline: &[u8]) -> bool {
+    cmdline
+        .split(|b| *b == 0)
+        .filter(|arg| !arg.is_empty())
+        .any(|arg| arg == b"muxd")
+}
+
+fn parse_environ(environ: &[u8]) -> HashMap<String, String> {
+    let mut vars = HashMap::new();
+
+    for entry in environ.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
+        let mut parts = entry.splitn(2, |b| *b == b'=');
+        let Some(key) = parts.next() else {
+            continue;
+        };
+        let Some(value) = parts.next() else {
+            continue;
+        };
+
+        let (Ok(key), Ok(value)) = (std::str::from_utf8(key), std::str::from_utf8(value)) else {
+            continue;
+        };
+
+        vars.insert(key.to_string(), value.to_string());
+    }
+
+    vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_cmdline_contains_muxd() {
+        assert!(cmdline_contains_muxd(b"tenex\0muxd\0"));
+        assert!(!cmdline_contains_muxd(b"tenex\0\0"));
+    }
+
+    #[test]
+    fn test_parse_environ() {
+        let env = b"A=1\0TENEX_MUX_SOCKET=test\0B=2\0";
+        let parsed = parse_environ(env);
+        assert_eq!(parsed.get("A"), Some(&"1".to_string()));
+        assert_eq!(parsed.get("TENEX_MUX_SOCKET"), Some(&"test".to_string()));
+        assert_eq!(parsed.get("B"), Some(&"2".to_string()));
+    }
+
+    #[test]
+    fn test_discover_socket_for_sessions_returns_none_for_empty_input() {
+        let wanted_sessions: HashSet<String> = HashSet::new();
+        assert!(discover_socket_for_sessions(&wanted_sessions, None).is_none());
+    }
+
+    #[test]
+    fn test_discover_socket_for_sessions_finds_matching_session() -> Result<()> {
+        let session_manager = crate::mux::SessionManager::new();
+        let session_name = format!("tenex-test-discovery-{}", uuid::Uuid::new_v4());
+        let workdir = TempDir::new()?;
+        session_manager.create(&session_name, workdir.path(), None)?;
+
+        let socket = crate::mux::socket_display()?;
+
+        let mut wanted_sessions = HashSet::new();
+        wanted_sessions.insert(session_name.clone());
+
+        let discovered = discover_socket_for_sessions(&wanted_sessions, Some(&socket));
+
+        let _ = session_manager.kill(&session_name);
+
+        anyhow::ensure!(
+            discovered.as_deref() == Some(socket.as_str()),
+            "Expected to rediscover mux socket"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_discover_socket_for_sessions_returns_none_when_no_matches() -> Result<()> {
+        let session_manager = crate::mux::SessionManager::new();
+        let existing_session = format!("tenex-test-discovery-existing-{}", uuid::Uuid::new_v4());
+        let workdir = TempDir::new()?;
+        session_manager.create(&existing_session, workdir.path(), None)?;
+
+        let mut wanted_sessions = HashSet::new();
+        wanted_sessions.insert(format!(
+            "tenex-test-discovery-missing-{}",
+            uuid::Uuid::new_v4()
+        ));
+
+        let socket = crate::mux::socket_display()?;
+        let discovered = discover_socket_for_sessions(&wanted_sessions, Some(&socket));
+        let _ = session_manager.kill(&existing_session);
+        assert!(discovered.is_none());
+        Ok(())
+    }
+}

--- a/src/mux/endpoint.rs
+++ b/src/mux/endpoint.rs
@@ -99,7 +99,16 @@ pub fn socket_endpoint() -> Result<SocketEndpoint> {
     })
 }
 
-fn socket_endpoint_from_value(value: &str) -> Result<SocketEndpoint> {
+/// Resolve a mux socket endpoint from a display value.
+///
+/// This mirrors the parsing rules of `TENEX_MUX_SOCKET`:
+/// - Values containing a path separator are treated as filesystem socket paths.
+/// - Otherwise, values are treated as namespaced socket names when supported.
+///
+/// # Errors
+///
+/// Returns an error if the endpoint cannot be constructed.
+pub(super) fn socket_endpoint_from_value(value: &str) -> Result<SocketEndpoint> {
     let display = value.to_string();
     let looks_like_path = display.contains('/') || display.contains('\\');
 

--- a/src/tui/input/mouse.rs
+++ b/src/tui/input/mouse.rs
@@ -256,7 +256,6 @@ mod tests {
             "echo".to_string(),
             format!("tenex/{title}"),
             PathBuf::from("/tmp"),
-            None,
         );
         app.data.storage.add(agent);
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -452,7 +452,6 @@ mod tests {
             "claude".to_string(),
             "branch".to_string(),
             PathBuf::from("/tmp"),
-            None,
         ));
         app.data.selected = 0;
 

--- a/src/tui/render/main_layout.rs
+++ b/src/tui/render/main_layout.rs
@@ -592,7 +592,6 @@ mod tests {
             "claude".to_string(),
             "branch".to_string(),
             std::path::PathBuf::from("/tmp"),
-            None,
         );
         let agent_id = agent.id;
         app.data.storage.add(agent);
@@ -616,7 +615,6 @@ mod tests {
             "claude".to_string(),
             "branch".to_string(),
             std::path::PathBuf::from("/tmp"),
-            None,
         );
         let agent_id = agent.id;
         app.data.storage.add(agent);
@@ -640,7 +638,6 @@ mod tests {
             "claude".to_string(),
             "branch".to_string(),
             std::path::PathBuf::from("/tmp"),
-            None,
         );
         let agent_id = agent.id;
         app.data.storage.add(agent);

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -262,7 +262,6 @@ mod tests {
             "echo".to_string(),
             format!("tenex-render-test-{pid}/{title}"),
             PathBuf::from(format!("/tmp/tenex-render-test-{pid}/{title}")),
-            None,
         );
         agent.set_status(status);
         agent
@@ -698,7 +697,6 @@ mod tests {
             "echo".to_string(),
             "test".to_string(),
             PathBuf::from("/tmp/tenex-render-test-child-visible"),
-            None,
             crate::agent::ChildConfig {
                 parent_id: expanded_root_id,
                 mux_session: expanded_root_mux_session,
@@ -716,7 +714,6 @@ mod tests {
             "echo".to_string(),
             "test".to_string(),
             PathBuf::from("/tmp/tenex-render-test-child-hidden"),
-            None,
             crate::agent::ChildConfig {
                 parent_id: collapsed_root_id,
                 mux_session: collapsed_root_mux_session,

--- a/src/tui/render/modals/confirm.rs
+++ b/src/tui/render/modals/confirm.rs
@@ -531,7 +531,6 @@ mod tests {
             "echo".to_string(),
             "tenex/render-agent".to_string(),
             PathBuf::from("/tmp"),
-            None,
         );
         let id = agent.id;
         app.data.storage.add(agent);

--- a/src/tui/render/modals/mod.rs
+++ b/src/tui/render/modals/mod.rs
@@ -294,7 +294,6 @@ mod tests {
             "echo".to_string(),
             format!("tenex-modal-rect-test-{pid}/{title}"),
             PathBuf::from(format!("/tmp/tenex-modal-rect-test-{pid}/{title}")),
-            None,
         );
         let id = agent.id;
         app.data.storage.add(agent);

--- a/tests/common/agent_factory.rs
+++ b/tests/common/agent_factory.rs
@@ -9,7 +9,6 @@ pub fn create_child_agent(parent: &Agent, title: &str, window_index: u32) -> Age
         "echo".to_string(),
         parent.branch.clone(),
         parent.worktree_path.clone(),
-        None,
         ChildConfig {
             parent_id: parent.id,
             mux_session: parent.mux_session.clone(),

--- a/tests/integration/agent.rs
+++ b/tests/integration/agent.rs
@@ -15,14 +15,12 @@ fn test_cmd_list_shows_agents() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         fixture.session_name("agent1"),
         fixture.worktree_path().join("agent1"),
-        None,
     );
     let agent2 = Agent::new(
         "test-agent-2".to_string(),
         "echo".to_string(),
         fixture.session_name("agent2"),
         fixture.worktree_path().join("agent2"),
-        None,
     );
 
     storage.add(agent1);
@@ -47,7 +45,6 @@ fn test_cmd_list_filter_running() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         fixture.session_name("running"),
         fixture.worktree_path().join("running"),
-        None,
     );
     agent1.set_status(Status::Running);
 
@@ -56,7 +53,6 @@ fn test_cmd_list_filter_running() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         fixture.session_name("starting"),
         fixture.worktree_path().join("starting"),
-        None,
     );
     agent2.set_status(Status::Starting);
 
@@ -84,7 +80,6 @@ fn test_find_agent_by_short_id_integration() -> Result<(), Box<dyn std::error::E
         "echo".to_string(),
         fixture.session_name("findable"),
         fixture.worktree_path().join("findable"),
-        None,
     );
     let short_id = agent.short_id();
     let full_id = agent.id;
@@ -108,14 +103,12 @@ fn test_find_agent_by_index_integration() -> Result<(), Box<dyn std::error::Erro
         "echo".to_string(),
         fixture.session_name("idx0"),
         fixture.worktree_path().join("idx0"),
-        None,
     ));
     storage.add(Agent::new(
         "agent-1".to_string(),
         "echo".to_string(),
         fixture.session_name("idx1"),
         fixture.worktree_path().join("idx1"),
-        None,
     ));
 
     // Find by index
@@ -142,7 +135,6 @@ fn test_agent_status_transitions() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         fixture.session_name("status"),
         fixture.worktree_path().join("status"),
-        None,
     );
 
     // Initial status should be Starting

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -68,7 +68,6 @@ fn setup_app_with_repo(fixture: &TestFixture) -> tenex::App {
         "echo".to_string(),
         fixture.session_name("diff"),
         fixture.repo_path.clone(),
-        None,
     ));
     app.data.selected = 0;
     app.data.active_tab = Tab::Diff;

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -82,7 +82,6 @@ fn test_execute_rename_same_name() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "test-branch".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -131,7 +130,6 @@ fn test_execute_push_with_valid_agent() -> Result<(), Box<dyn std::error::Error>
         "echo".to_string(),
         branch_name.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -188,7 +186,6 @@ fn test_execute_rebase_with_valid_agent() -> Result<(), Box<dyn std::error::Erro
         "echo".to_string(),
         branch_name.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -249,7 +246,6 @@ fn test_execute_merge_with_valid_agent() -> Result<(), Box<dyn std::error::Error
         "echo".to_string(),
         branch_name.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -287,7 +283,6 @@ fn test_push_action_handler() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "feature/test".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -321,7 +316,6 @@ fn test_rename_action_handler() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "feature/rename".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -360,7 +354,6 @@ fn test_rebase_action_handler() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "feature/rebase".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     app.data.storage.add(agent);
 
@@ -396,7 +389,6 @@ fn test_merge_action_handler() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "feature/merge".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     app.data.storage.add(agent);
 
@@ -434,7 +426,6 @@ fn test_open_pr_action_handler() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         branch_name.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -476,7 +467,6 @@ fn test_execute_root_rename_with_real_worktree() -> Result<(), Box<dyn std::erro
         "echo".to_string(),
         old_branch.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -517,7 +507,6 @@ fn test_execute_subagent_rename() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "tenex-root".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     let root_id = root.id;
     let root_session = root.mux_session.clone();
@@ -529,7 +518,6 @@ fn test_execute_subagent_rename() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "tenex-root".to_string(),
         fixture.repo_path.clone(),
-        None,
         tenex::agent::ChildConfig {
             parent_id: root_id,
             mux_session: root_session,
@@ -619,7 +607,6 @@ fn test_execute_rebase_with_conflict() -> Result<(), Box<dyn std::error::Error>>
         "echo".to_string(),
         branch_name.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -726,7 +713,6 @@ fn test_execute_merge_with_conflict() -> Result<(), Box<dyn std::error::Error>> 
         "echo".to_string(),
         branch_name.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -803,7 +789,6 @@ fn test_execute_push_and_open_pr_no_remote() -> Result<(), Box<dyn std::error::E
         "echo".to_string(),
         branch_name.to_string(),
         worktree_path,
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -841,7 +826,6 @@ fn test_rename_unchanged_name() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         "tenex-same".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -887,7 +871,6 @@ fn test_execute_rebase_no_target_branch() -> Result<(), Box<dyn std::error::Erro
         "echo".to_string(),
         "tenex-feature".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -928,7 +911,6 @@ fn test_execute_merge_no_target_branch() -> Result<(), Box<dyn std::error::Error
         "echo".to_string(),
         "tenex-feature".to_string(),
         fixture.repo_path.clone(),
-        None,
     );
     let agent_id = agent.id;
     app.data.storage.add(agent);
@@ -974,7 +956,6 @@ fn test_execute_rename_with_descendants() -> Result<(), Box<dyn std::error::Erro
         "echo".to_string(),
         old_branch.to_string(),
         worktree_path.clone(),
-        None,
     );
     let root_id = root.id;
     let root_session = root.mux_session.clone();
@@ -987,7 +968,6 @@ fn test_execute_rename_with_descendants() -> Result<(), Box<dyn std::error::Erro
             "echo".to_string(),
             old_branch.to_string(),
             worktree_path.clone(),
-            None,
             tenex::agent::ChildConfig {
                 parent_id: root_id,
                 mux_session: root_session.clone(),

--- a/tests/integration/hierarchy.rs
+++ b/tests/integration/hierarchy.rs
@@ -711,7 +711,6 @@ fn test_visible_agents_with_info_hierarchy() {
         "echo".to_string(),
         "branch1".to_string(),
         PathBuf::from("/tmp/root1"),
-        None,
     );
     root1.collapsed = false; // Expanded
 
@@ -726,7 +725,6 @@ fn test_visible_agents_with_info_hierarchy() {
         "echo".to_string(),
         "branch2".to_string(),
         PathBuf::from("/tmp/root2"),
-        None,
     );
     // root2.collapsed = true is default
 

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -26,21 +26,18 @@ fn test_sync_agent_status_batched_session_check() -> Result<(), Box<dyn std::err
         "echo".to_string(),
         fixture.session_name("agent1"),
         fixture.worktree_path(),
-        None,
     );
     let agent2 = Agent::new(
         "agent2".to_string(),
         "echo".to_string(),
         fixture.session_name("agent2"),
         fixture.worktree_path(),
-        None,
     );
     let agent3 = Agent::new(
         "agent3".to_string(),
         "echo".to_string(),
         fixture.session_name("agent3"),
         fixture.worktree_path(),
-        None,
     );
 
     let agent1_session = agent1.mux_session.clone();
@@ -104,7 +101,6 @@ fn test_reserve_window_indices_consecutive() {
         "echo".to_string(),
         "branch".to_string(),
         PathBuf::from("/tmp/root"),
-        None,
     );
     let root_id = root.id;
     storage.add(root.clone());
@@ -157,7 +153,6 @@ fn test_large_swarm_sync_status() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         fixture.session_name("root"),
         fixture.worktree_path(),
-        None,
     );
     let root_session = root.mux_session.clone();
     let root_id = root.id;

--- a/tests/integration/persistence.rs
+++ b/tests/integration/persistence.rs
@@ -15,7 +15,6 @@ fn test_storage_save_and_load() -> Result<(), Box<dyn std::error::Error>> {
         "echo".to_string(),
         fixture.session_name("persist"),
         fixture.worktree_path().join("persist"),
-        None,
     ));
 
     // Save to file

--- a/tests/integration/workflow.rs
+++ b/tests/integration/workflow.rs
@@ -38,7 +38,6 @@ fn test_agent_creation_workflow() -> Result<(), Box<dyn std::error::Error>> {
         config.default_program,
         branch.clone(),
         worktree_path.clone(),
-        None,
     );
     let agent_id = agent.id;
     storage.add(agent);
@@ -197,7 +196,6 @@ fn test_full_cli_workflow() -> Result<(), Box<dyn std::error::Error>> {
         config.default_program,
         branch.clone(),
         worktree_path,
-        None,
     );
     agent.set_status(tenex::Status::Running);
     let agent_id = agent.id;


### PR DESCRIPTION
Fixes Tenex restart behavior so persisted agents are actually running again after restarting Tenex or a forced reboot.

- Stop persisting any initial prompt text
- Persist mux socket per instance and discover/reuse existing mux daemons across rebuilds
- On startup, respawn missing mux sessions/windows using each agent's stored program (including terminals/children)
- Add regression + discovery tests (coverage stays ≥90%)