### PR TITLE
Persist agent program settings per role

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ tenex
 
 ## Configuration
 
-The default agent command is `claude --allow-dangerously-skip-permissions`. Press `/` to open the command palette, run `/agents`, and choose the default program for new agents (`claude`, `codex`, or `custom` — which will prompt for a command and save it to `settings.json`).
+The default agent command is `claude --allow-dangerously-skip-permissions`. Press `/` to open the command palette, run `/agents`, then choose which agent type to configure (default/planner/review).
 
 ### Data Storage
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -34,7 +34,8 @@ use crate::state::{
     CustomAgentCommandMode, DiffFocusedMode, ErrorModalMode, HelpMode, KeyboardRemapPromptMode,
     MergeBranchSelectorMode, ModelSelectorMode, NormalMode, PreviewFocusedMode, PromptingMode,
     RebaseBranchSelectorMode, ReconnectPromptMode, RenameBranchMode, ReviewChildCountMode,
-    ReviewInfoMode, ScrollingMode, SuccessModalMode, TerminalPromptMode, UpdatePromptMode,
+    ReviewInfoMode, ScrollingMode, SettingsMenuMode, SuccessModalMode, TerminalPromptMode,
+    UpdatePromptMode,
 };
 use crate::update::UpdateInfo;
 use anyhow::Result;
@@ -548,6 +549,27 @@ pub fn dispatch_model_selector_mode(app: &mut App, code: KeyCode) -> Result<()> 
             KeyCode::Char(c) => CharInputAction(c).execute(ModelSelectorMode, app_data)?,
             KeyCode::Backspace => BackspaceAction.execute(ModelSelectorMode, app_data)?,
             _ => ModelSelectorMode.into(),
+        }
+    };
+
+    app.apply_mode(next);
+    Ok(())
+}
+
+/// Dispatch a raw key event while in `SettingsMenuMode`, using typed actions.
+///
+/// # Errors
+///
+/// Returns an error if the dispatched action fails.
+pub fn dispatch_settings_menu_mode(app: &mut App, code: KeyCode) -> Result<()> {
+    let next = {
+        let app_data = &mut app.data;
+        match code {
+            KeyCode::Esc => CancelAction.execute(SettingsMenuMode, app_data)?,
+            KeyCode::Enter => SelectAction.execute(SettingsMenuMode, app_data)?,
+            KeyCode::Up => NavigateUpAction.execute(SettingsMenuMode, app_data)?,
+            KeyCode::Down => NavigateDownAction.execute(SettingsMenuMode, app_data)?,
+            _ => SettingsMenuMode.into(),
         }
     };
 

--- a/src/action/picker.rs
+++ b/src/action/picker.rs
@@ -8,7 +8,7 @@ use crate::app::{Actions, AppData};
 use crate::state::{
     AppMode, BranchSelectorMode, ChildCountMode, ChildPromptMode, CommandPaletteMode,
     ErrorModalMode, MergeBranchSelectorMode, ModelSelectorMode, RebaseBranchSelectorMode,
-    ReviewChildCountMode, ReviewInfoMode,
+    ReviewChildCountMode, ReviewInfoMode, SettingsMenuMode,
 };
 use anyhow::Result;
 
@@ -198,6 +198,14 @@ impl ValidIn<CommandPaletteMode> for CancelAction {
     }
 }
 
+impl ValidIn<SettingsMenuMode> for CancelAction {
+    type NextState = AppMode;
+
+    fn execute(self, _state: SettingsMenuMode, _app_data: &mut AppData) -> Result<Self::NextState> {
+        Ok(AppMode::normal())
+    }
+}
+
 impl ValidIn<BranchSelectorMode> for NavigateUpAction {
     type NextState = AppMode;
 
@@ -320,6 +328,24 @@ impl ValidIn<CommandPaletteMode> for NavigateDownAction {
     }
 }
 
+impl ValidIn<SettingsMenuMode> for NavigateUpAction {
+    type NextState = AppMode;
+
+    fn execute(self, _state: SettingsMenuMode, app_data: &mut AppData) -> Result<Self::NextState> {
+        app_data.select_prev_settings_menu_item();
+        Ok(SettingsMenuMode.into())
+    }
+}
+
+impl ValidIn<SettingsMenuMode> for NavigateDownAction {
+    type NextState = AppMode;
+
+    fn execute(self, _state: SettingsMenuMode, app_data: &mut AppData) -> Result<Self::NextState> {
+        app_data.select_next_settings_menu_item();
+        Ok(SettingsMenuMode.into())
+    }
+}
+
 impl ValidIn<BranchSelectorMode> for SelectAction {
     type NextState = AppMode;
 
@@ -400,6 +426,14 @@ impl ValidIn<CommandPaletteMode> for SelectAction {
         app_data: &mut AppData,
     ) -> Result<Self::NextState> {
         Ok(app_data.confirm_slash_command_selection())
+    }
+}
+
+impl ValidIn<SettingsMenuMode> for SelectAction {
+    type NextState = AppMode;
+
+    fn execute(self, _state: SettingsMenuMode, app_data: &mut AppData) -> Result<Self::NextState> {
+        Ok(app_data.confirm_settings_menu_selection())
     }
 }
 

--- a/src/action/text_input.rs
+++ b/src/action/text_input.rs
@@ -1099,9 +1099,24 @@ impl ValidIn<CustomAgentCommandMode> for SubmitAction {
             return Ok(CustomAgentCommandMode.into());
         }
 
+        let role = app_data.model_selector.role;
         let command = input.trim().to_string();
-        app_data.settings.custom_agent_command = command;
-        app_data.settings.agent_program = crate::app::AgentProgram::Custom;
+
+        match role {
+            crate::app::AgentRole::Default => {
+                app_data.settings.custom_agent_command = command;
+                app_data.settings.agent_program = crate::app::AgentProgram::Custom;
+            }
+            crate::app::AgentRole::Planner => {
+                app_data.settings.planner_custom_agent_command = command;
+                app_data.settings.planner_agent_program = crate::app::AgentProgram::Custom;
+            }
+            crate::app::AgentRole::Review => {
+                app_data.settings.review_custom_agent_command = command;
+                app_data.settings.review_agent_program = crate::app::AgentProgram::Custom;
+            }
+        }
+
         if let Err(err) = app_data.settings.save() {
             return Ok(ErrorModalMode {
                 message: format!("Failed to save settings: {err}"),
@@ -1109,7 +1124,7 @@ impl ValidIn<CustomAgentCommandMode> for SubmitAction {
             .into());
         }
 
-        app_data.set_status("Model set to custom");
+        app_data.set_status(format!("{} set to custom", role.menu_label()));
         Ok(AppMode::normal())
     }
 }

--- a/src/app/handlers/swarm.rs
+++ b/src/app/handlers/swarm.rs
@@ -199,7 +199,11 @@ impl Actions {
         let start_window_index = app_data
             .storage
             .reserve_window_indices(config.parent_agent_id);
-        let program = app_data.agent_spawn_command();
+        let program = if app_data.spawn.use_plan_prompt {
+            app_data.planner_agent_spawn_command()
+        } else {
+            app_data.agent_spawn_command()
+        };
         let child_prompt =
             task.map(|t| Self::build_child_prompt(t, app_data.spawn.use_plan_prompt));
 
@@ -337,7 +341,7 @@ impl Actions {
 
         // Reserve window indices
         let start_window_index = app_data.storage.reserve_window_indices(parent_id);
-        let program = app_data.agent_spawn_command();
+        let program = app_data.review_agent_spawn_command();
 
         // Create review child agents
         for i in 0..count {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,5 +10,5 @@ pub use crate::state::ConfirmAction;
 pub use data::AppData;
 pub use event::{Event, Handler};
 pub use handlers::Actions;
-pub use settings::{AgentProgram, Settings};
+pub use settings::{AgentProgram, AgentRole, Settings};
 pub use state::{App, BranchInfo, DiffEdit, DiffLineMeta, InputMode, Tab, WorktreeConflictInfo};

--- a/src/app/state/command_palette.rs
+++ b/src/app/state/command_palette.rs
@@ -21,7 +21,8 @@ impl CommandPaletteState {
 }
 
 use super::{App, SlashCommand};
-use crate::state::{AppMode, CommandPaletteMode, HelpMode, ModelSelectorMode};
+use crate::app::AgentRole;
+use crate::state::{AppMode, CommandPaletteMode, HelpMode, SettingsMenuMode};
 
 impl App {
     /// Enter slash command palette mode and pre-fill the leading `/`
@@ -46,7 +47,8 @@ impl App {
         let next = match cmd.name {
             "/agents" => {
                 self.data.input.clear();
-                ModelSelectorMode.into()
+                self.data.model_selector.role = AgentRole::Default;
+                SettingsMenuMode.into()
             }
             "/help" => {
                 self.data.ui.help_scroll = 0;

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -11,6 +11,7 @@ mod models;
 mod navigation;
 mod review;
 mod scroll;
+mod settings_menu;
 mod spawn;
 mod text_input;
 mod ui;
@@ -20,6 +21,7 @@ pub use git_op::GitOpState;
 pub use input::InputState;
 pub use models::ModelSelectorState;
 pub use review::ReviewState;
+pub use settings_menu::SettingsMenuState;
 pub use spawn::SpawnState;
 pub use spawn::WorktreeConflictInfo;
 pub use ui::{DiffEdit, DiffLineMeta, UiState};
@@ -47,7 +49,7 @@ pub struct SlashCommand {
 pub const SLASH_COMMANDS: &[SlashCommand] = &[
     SlashCommand {
         name: "/agents",
-        description: "Select default agent model/program",
+        description: "Configure agent programs (default/planner/review)",
     },
     SlashCommand {
         name: "/help",

--- a/src/app/state/models.rs
+++ b/src/app/state/models.rs
@@ -1,6 +1,7 @@
 //! Model selector state: selecting which agent command to run by default
 
 use crate::app::AgentProgram;
+use crate::app::AgentRole;
 
 /// State for the `/agents` selector modal
 #[derive(Debug, Default)]
@@ -10,6 +11,9 @@ pub struct ModelSelectorState {
 
     /// Currently selected index in filtered list
     pub selected: usize,
+
+    /// Which setting is being edited (default/planner/review).
+    pub role: AgentRole,
 }
 
 impl ModelSelectorState {
@@ -19,6 +23,7 @@ impl ModelSelectorState {
         Self {
             filter: String::new(),
             selected: 0,
+            role: AgentRole::Default,
         }
     }
 
@@ -91,6 +96,7 @@ use crate::state::{CustomAgentCommandMode, ModelSelectorMode};
 impl App {
     /// Enter the `/agents` selector modal.
     pub fn start_model_selector(&mut self) {
+        self.data.model_selector.role = AgentRole::Default;
         self.apply_mode(ModelSelectorMode.into());
     }
 
@@ -134,6 +140,7 @@ impl App {
 
     /// Open the custom agent command prompt (used when selecting `custom`).
     pub fn start_custom_agent_command_prompt(&mut self) {
+        self.data.model_selector.role = AgentRole::Default;
         self.apply_mode(CustomAgentCommandMode.into());
         self.data
             .input
@@ -190,6 +197,7 @@ mod tests {
         let state = ModelSelectorState::new();
         assert!(state.filter.is_empty());
         assert_eq!(state.selected, 0);
+        assert_eq!(state.role, AgentRole::Default);
     }
 
     #[test]
@@ -197,6 +205,7 @@ mod tests {
         let state = ModelSelectorState::default();
         assert!(state.filter.is_empty());
         assert_eq!(state.selected, 0);
+        assert_eq!(state.role, AgentRole::Default);
     }
 
     #[test]

--- a/src/app/state/settings_menu.rs
+++ b/src/app/state/settings_menu.rs
@@ -1,0 +1,99 @@
+//! Settings menu state: selecting which setting to edit.
+
+use crate::app::AgentRole;
+
+/// State for the `/agents` role selection menu.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SettingsMenuState {
+    /// Currently selected index in the menu list.
+    pub selected: usize,
+}
+
+impl SettingsMenuState {
+    /// Create a new settings menu state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { selected: 0 }
+    }
+
+    /// Reset selection back to the first entry.
+    pub const fn reset(&mut self) {
+        self.selected = 0;
+    }
+
+    /// Select the next menu item.
+    pub const fn select_next(&mut self) {
+        let count = AgentRole::ALL.len();
+        if count > 0 {
+            self.selected = (self.selected + 1) % count;
+        } else {
+            self.selected = 0;
+        }
+    }
+
+    /// Select the previous menu item.
+    pub const fn select_prev(&mut self) {
+        let count = AgentRole::ALL.len();
+        if count == 0 {
+            self.selected = 0;
+            return;
+        }
+
+        if self.selected == 0 {
+            self.selected = count - 1;
+        } else {
+            self.selected -= 1;
+        }
+    }
+
+    /// Return the currently highlighted role.
+    #[must_use]
+    pub const fn selected_role(self) -> AgentRole {
+        match self.selected {
+            1 => AgentRole::Planner,
+            2 => AgentRole::Review,
+            _ => AgentRole::Default,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let state = SettingsMenuState::new();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut state = SettingsMenuState::new();
+        state.selected = 2;
+        state.reset();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn test_select_next_wraps() {
+        let mut state = SettingsMenuState::new();
+        state.selected = AgentRole::ALL.len() - 1;
+        state.select_next();
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn test_select_prev_wraps() {
+        let mut state = SettingsMenuState::new();
+        state.selected = 0;
+        state.select_prev();
+        assert_eq!(state.selected, AgentRole::ALL.len() - 1);
+    }
+
+    #[test]
+    fn test_selected_role_defaults() {
+        let state = SettingsMenuState { selected: 99 };
+        assert_eq!(state.selected_role(), AgentRole::Default);
+    }
+}

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -568,7 +568,7 @@ fn test_run_slash_command_agents() {
         name: "/agents",
         description: "test",
     });
-    assert_eq!(app.mode, AppMode::ModelSelector(ModelSelectorMode));
+    assert_eq!(app.mode, AppMode::SettingsMenu(SettingsMenuMode));
 }
 
 #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -25,6 +25,7 @@ mod rename_branch;
 mod review_child_count;
 mod review_info;
 mod scrolling;
+mod settings_menu;
 mod success_modal;
 mod terminal_prompt;
 mod update_prompt;
@@ -55,6 +56,7 @@ pub use rename_branch::RenameBranchMode;
 pub use review_child_count::ReviewChildCountMode;
 pub use review_info::ReviewInfoMode;
 pub use scrolling::ScrollingMode;
+pub use settings_menu::SettingsMenuMode;
 pub use success_modal::SuccessModalMode;
 pub use terminal_prompt::TerminalPromptMode;
 pub use update_prompt::UpdatePromptMode;
@@ -95,6 +97,8 @@ pub enum AppMode {
     MergeBranchSelector(MergeBranchSelectorMode),
     /// Model selector mode.
     ModelSelector(ModelSelectorMode),
+    /// Settings menu mode.
+    SettingsMenu(SettingsMenuMode),
     /// Command palette mode.
     CommandPalette(CommandPaletteMode),
     /// General confirmation mode (requires carrying the confirmed action).
@@ -236,6 +240,12 @@ impl From<MergeBranchSelectorMode> for AppMode {
 impl From<ModelSelectorMode> for AppMode {
     fn from(_: ModelSelectorMode) -> Self {
         Self::ModelSelector(ModelSelectorMode)
+    }
+}
+
+impl From<SettingsMenuMode> for AppMode {
+    fn from(_: SettingsMenuMode) -> Self {
+        Self::SettingsMenu(SettingsMenuMode)
     }
 }
 

--- a/src/state/settings_menu.rs
+++ b/src/state/settings_menu.rs
@@ -1,0 +1,5 @@
+//! Settings menu mode state type (new architecture).
+
+/// Settings menu mode - pick which setting to edit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SettingsMenuMode;

--- a/src/tui/input/command.rs
+++ b/src/tui/input/command.rs
@@ -14,13 +14,18 @@ pub fn handle_model_selector_mode(app: &mut App, code: KeyCode) -> Result<()> {
     crate::action::dispatch_model_selector_mode(app, code)
 }
 
+/// Handle key events in `SettingsMenu` mode
+pub fn handle_settings_menu_mode(app: &mut App, code: KeyCode) -> Result<()> {
+    crate::action::dispatch_settings_menu_mode(app, code)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::agent::Storage;
     use crate::app::Settings;
     use crate::config::Config;
-    use crate::state::{AppMode, CommandPaletteMode, ModelSelectorMode};
+    use crate::state::{AppMode, CommandPaletteMode, ModelSelectorMode, SettingsMenuMode};
     use tempfile::NamedTempFile;
 
     fn create_test_app() -> Result<(App, NamedTempFile), std::io::Error> {
@@ -163,6 +168,32 @@ mod tests {
         handle_model_selector_mode(&mut app, KeyCode::Tab)?;
         assert_eq!(app.data.model_selector.selected, selected);
         assert_eq!(app.mode, ModelSelectorMode.into());
+        Ok(())
+    }
+
+    // ========== SettingsMenu mode tests ==========
+
+    #[test]
+    fn test_settings_menu_esc_exits() -> Result<(), Box<dyn std::error::Error>> {
+        let (mut app, _temp) = create_test_app()?;
+        app.apply_mode(SettingsMenuMode.into());
+
+        handle_settings_menu_mode(&mut app, KeyCode::Esc)?;
+        assert_eq!(app.mode, AppMode::normal());
+        Ok(())
+    }
+
+    #[test]
+    fn test_settings_menu_up_down_navigation() -> Result<(), Box<dyn std::error::Error>> {
+        let (mut app, _temp) = create_test_app()?;
+        app.apply_mode(SettingsMenuMode.into());
+        assert_eq!(app.data.settings_menu.selected, 0);
+
+        handle_settings_menu_mode(&mut app, KeyCode::Down)?;
+        assert_eq!(app.data.settings_menu.selected, 1);
+
+        handle_settings_menu_mode(&mut app, KeyCode::Up)?;
+        assert_eq!(app.data.settings_menu.selected, 0);
         Ok(())
     }
 }

--- a/src/tui/input/mod.rs
+++ b/src/tui/input/mod.rs
@@ -111,6 +111,9 @@ pub fn handle_key_event(
         AppMode::ModelSelector(_) => {
             command::handle_model_selector_mode(app, code)?;
         }
+        AppMode::SettingsMenu(_) => {
+            command::handle_settings_menu_mode(app, code)?;
+        }
 
         // Preview focused mode (forwards keys to the mux backend)
         AppMode::PreviewFocused(_) => {

--- a/src/tui/render/modals/mod.rs
+++ b/src/tui/render/modals/mod.rs
@@ -11,6 +11,7 @@ mod help;
 mod input;
 mod models;
 mod picker;
+mod settings_menu;
 
 pub use branch::render_branch_selector_overlay;
 pub use command_palette::render_command_palette_overlay;
@@ -25,6 +26,7 @@ pub use models::render_model_selector_overlay;
 pub use picker::{
     render_count_picker_overlay, render_review_count_picker_overlay, render_review_info_overlay,
 };
+pub use settings_menu::render_settings_menu_overlay;
 
 use crate::app::App;
 use crate::config::Action;
@@ -77,6 +79,7 @@ pub fn modal_rect_for_mode(app: &App, frame_area: Rect) -> Option<Rect> {
         | AppMode::RebaseBranchSelector(_)
         | AppMode::MergeBranchSelector(_) => Some(centered_rect_absolute(60, 20, frame_area)),
         AppMode::ModelSelector(_) => Some(centered_rect_absolute(55, 12, frame_area)),
+        AppMode::SettingsMenu(_) => Some(centered_rect_absolute(60, 9, frame_area)),
         AppMode::ConfirmPush(_) => Some(confirm_push_rect(app, frame_area)),
         AppMode::RenameBranch(_) => Some(centered_rect_absolute(55, 9, frame_area)),
         AppMode::ConfirmPushForPR(_) | AppMode::UpdatePrompt(_) => {

--- a/src/tui/render/modals/models.rs
+++ b/src/tui/render/modals/models.rs
@@ -1,5 +1,6 @@
 //! Model selector modal rendering (`/agents`)
 
+use crate::app::AgentRole;
 use crate::app::App;
 use ratatui::{
     Frame,
@@ -18,7 +19,12 @@ pub fn render_model_selector_overlay(frame: &mut Frame<'_>, app: &App) {
 
     let filtered = app.filtered_model_programs();
     let selected_idx = app.data.model_selector.selected;
-    let current = app.data.settings.agent_program;
+    let role = app.data.model_selector.role;
+    let current = match role {
+        AgentRole::Default => app.data.settings.agent_program,
+        AgentRole::Planner => app.data.settings.planner_agent_program,
+        AgentRole::Review => app.data.settings.review_agent_program,
+    };
 
     let mut lines: Vec<Line<'_>> = Vec::new();
 
@@ -80,7 +86,7 @@ pub fn render_model_selector_overlay(frame: &mut Frame<'_>, app: &App) {
     let paragraph = Paragraph::new(lines)
         .block(
             Block::default()
-                .title(" Models ")
+                .title(format!(" Models • {} ", role.menu_label()))
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(colors::SELECTED))
                 .border_type(colors::BORDER_TYPE),

--- a/src/tui/render/modals/settings_menu.rs
+++ b/src/tui/render/modals/settings_menu.rs
@@ -1,0 +1,103 @@
+//! Agent role selection modal rendering (`/agents`)
+
+use crate::app::{AgentRole, App};
+use ratatui::{
+    Frame,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+use super::centered_rect_absolute;
+use crate::tui::render::colors;
+
+/// Render the settings menu overlay.
+pub fn render_settings_menu_overlay(frame: &mut Frame<'_>, app: &App) {
+    // Header + blank + 3 items + blank + help = 7, plus borders = 9.
+    let area = centered_rect_absolute(60, 9, frame.area());
+
+    let total = AgentRole::ALL.len();
+    let selected_idx = app.data.settings_menu.selected.min(total.saturating_sub(1));
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    lines.push(Line::from(vec![Span::styled(
+        "Choose which agent type to configure:",
+        Style::default().fg(colors::TEXT_DIM),
+    )]));
+    lines.push(Line::from(""));
+
+    for (idx, role) in AgentRole::ALL.iter().copied().enumerate() {
+        let program = match role {
+            AgentRole::Default => app.data.settings.agent_program,
+            AgentRole::Planner => app.data.settings.planner_agent_program,
+            AgentRole::Review => app.data.settings.review_agent_program,
+        };
+
+        let is_selected = idx == selected_idx;
+        let style = if is_selected {
+            Style::default()
+                .fg(colors::TEXT_PRIMARY)
+                .bg(colors::SURFACE_HIGHLIGHT)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(colors::TEXT_PRIMARY)
+        };
+
+        let prefix = if is_selected { "▶ " } else { "  " };
+        lines.push(Line::from(Span::styled(
+            format!("{prefix}{}  ({})", role.menu_label(), program.label()),
+            style,
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "↑/↓ select • Enter edit • Esc cancel",
+        Style::default().fg(colors::TEXT_MUTED),
+    )));
+
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title(" Agents ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(colors::SELECTED))
+                .border_type(colors::BORDER_TYPE),
+        )
+        .style(Style::default().bg(colors::MODAL_BG));
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::Storage;
+    use crate::app::Settings;
+    use crate::config::Config;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn test_render_settings_menu_overlay_renders_content() -> Result<(), std::io::Error> {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend)?;
+
+        let mut app = App::new(
+            Config::default(),
+            Storage::new(),
+            Settings::default(),
+            false,
+        );
+        app.data.settings_menu.selected = 1;
+
+        terminal.draw(|frame| {
+            render_settings_menu_overlay(frame, &app);
+        })?;
+
+        assert!(!terminal.backend().buffer().content.is_empty());
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes #27

- Persist agent program settings for Default/Planner/Review between restarts, reboots, and upgrades
- `/agents` now opens a role submenu, then the existing program picker
- Planner (P) and Review (R) swarms use the configured role programs
- Upgrade-safe defaults: planner/review inherit existing agent settings on first run
