### PR TITLE
Add Commits tab for current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tenex lets you run multiple AI coding agents in parallel, each in an isolated gi
 - **Synthesis** — Aggregate outputs from descendant agents into a parent (captures last ~5000 lines from each, writes to markdown, then sends to parent)
 - **Live preview** — Watch agent output in real-time with ANSI color support; auto-follows bottom unless you scroll
 - **Diff view** — See uncommitted changes (staged + unstaged + untracked) vs HEAD in the selected agent's worktree
+- **Commits view** — See commits in the selected agent's branch (relative to base) in a dedicated tab
 - **Git operations** — Push, rebase, merge, rename branches, and open PRs from the TUI
 - **Command palette** — Run slash commands like `/agents` and `/help`
 - **Persistent state** — Agents survive restarts; auto-reconnects to existing worktrees on startup
@@ -100,10 +101,10 @@ tenex
 | `Enter` | Attach terminal (forward keystrokes to agent) |
 | `Ctrl+q` | Detach terminal / Quit (with confirm if agents running) |
 | `Esc` | Cancel current modal or flow |
-| `Tab` | Switch between Preview and Diff tabs |
+| `Tab` | Cycle tabs forward (Preview/Diff/Commits) |
 | `Space` | Collapse/expand agent tree |
-| `Ctrl+u` | Scroll preview/diff up |
-| `Ctrl+d` | Scroll preview/diff down |
+| `Ctrl+u` | Scroll preview/diff/commits up |
+| `Ctrl+d` | Scroll preview/diff/commits down |
 | `g` | Scroll to top |
 | `G` | Scroll to bottom |
 | `?` | Help |

--- a/src/action/git.rs
+++ b/src/action/git.rs
@@ -107,7 +107,7 @@ impl ValidIn<NormalMode> for OpenPRAction {
         let branch_name = agent.branch.clone();
         let worktree_path = agent.worktree_path.clone();
 
-        let base_branch = Actions::detect_base_branch(&worktree_path, &branch_name)?;
+        let base_branch = Actions::detect_base_branch(&worktree_path, &branch_name);
         let has_unpushed = Actions::has_unpushed_commits(&worktree_path, &branch_name)?;
 
         app_data
@@ -135,7 +135,7 @@ impl ValidIn<ScrollingMode> for OpenPRAction {
         let branch_name = agent.branch.clone();
         let worktree_path = agent.worktree_path.clone();
 
-        let base_branch = Actions::detect_base_branch(&worktree_path, &branch_name)?;
+        let base_branch = Actions::detect_base_branch(&worktree_path, &branch_name);
         let has_unpushed = Actions::has_unpushed_commits(&worktree_path, &branch_name)?;
 
         app_data

--- a/src/action/navigation.rs
+++ b/src/action/navigation.rs
@@ -214,6 +214,7 @@ impl ValidIn<NormalMode> for FocusPreviewAction {
             match app_data.active_tab {
                 Tab::Preview => Ok(PreviewFocusedMode.into()),
                 Tab::Diff => Ok(DiffFocusedMode.into()),
+                Tab::Commits => Ok(AppMode::normal()),
             }
         } else {
             Ok(AppMode::normal())
@@ -229,6 +230,7 @@ impl ValidIn<ScrollingMode> for FocusPreviewAction {
             match app_data.active_tab {
                 Tab::Preview => Ok(PreviewFocusedMode.into()),
                 Tab::Diff => Ok(DiffFocusedMode.into()),
+                Tab::Commits => Ok(ScrollingMode.into()),
             }
         } else {
             Ok(ScrollingMode.into())
@@ -284,6 +286,12 @@ mod tests {
             SwitchTabAction.execute(ScrollingMode, &mut data)?,
             ScrollingMode.into()
         );
+        assert_eq!(data.active_tab, Tab::Commits);
+
+        assert_eq!(
+            SwitchTabAction.execute(ScrollingMode, &mut data)?,
+            ScrollingMode.into()
+        );
         assert_eq!(data.active_tab, Tab::Preview);
 
         data.active_tab = Tab::Diff;
@@ -291,7 +299,8 @@ mod tests {
             SwitchTabAction.execute(DiffFocusedMode, &mut data)?,
             AppMode::normal()
         );
-        assert_eq!(data.active_tab, Tab::Preview);
+        assert_eq!(data.active_tab, Tab::Commits);
+
         Ok(())
     }
 

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -116,11 +116,12 @@ impl AppData {
         self.ui.set_status(message);
     }
 
-    /// Switch between preview and diff tabs.
+    /// Switch between detail pane tabs (forward).
     pub(crate) fn switch_tab(&mut self) {
         self.active_tab = match self.active_tab {
             Tab::Preview => Tab::Diff,
-            Tab::Diff => Tab::Preview,
+            Tab::Diff => Tab::Commits,
+            Tab::Commits => Tab::Preview,
         };
         self.ui.reset_scroll();
     }
@@ -197,6 +198,7 @@ impl AppData {
         match self.active_tab {
             Tab::Preview => self.ui.scroll_preview_up(amount),
             Tab::Diff => self.ui.scroll_diff_up(amount),
+            Tab::Commits => self.ui.scroll_commits_up(amount),
         }
     }
 
@@ -205,6 +207,7 @@ impl AppData {
         match self.active_tab {
             Tab::Preview => self.ui.scroll_preview_down(amount),
             Tab::Diff => self.ui.scroll_diff_down(amount),
+            Tab::Commits => self.ui.scroll_commits_down(amount),
         }
     }
 
@@ -213,6 +216,7 @@ impl AppData {
         match self.active_tab {
             Tab::Preview => self.ui.preview_to_top(),
             Tab::Diff => self.ui.diff_to_top(),
+            Tab::Commits => self.ui.commits_to_top(),
         }
     }
 
@@ -221,6 +225,7 @@ impl AppData {
         match self.active_tab {
             Tab::Preview => self.ui.preview_to_bottom(content_lines, visible_lines),
             Tab::Diff => self.ui.diff_to_bottom(content_lines, visible_lines),
+            Tab::Commits => self.ui.commits_to_bottom(content_lines, visible_lines),
         }
     }
 

--- a/src/app/handlers/git_ops/tests.rs
+++ b/src/app/handlers/git_ops/tests.rs
@@ -433,7 +433,7 @@ fn test_detect_base_branch_no_git() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
 
     // Should return default "main" when git commands fail
-    let result = Actions::detect_base_branch(temp_dir.path(), "feature/test")?;
+    let result = Actions::detect_base_branch(temp_dir.path(), "feature/test");
     assert_eq!(result, "main");
     Ok(())
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -114,6 +114,8 @@ pub enum Tab {
     Preview,
     /// Git diff view
     Diff,
+    /// Current branch commit list
+    Commits,
 }
 
 impl std::fmt::Display for Tab {
@@ -121,6 +123,7 @@ impl std::fmt::Display for Tab {
         match self {
             Self::Preview => write!(f, "Preview"),
             Self::Diff => write!(f, "Diff"),
+            Self::Commits => write!(f, "Commits"),
         }
     }
 }

--- a/src/app/state/navigation.rs
+++ b/src/app/state/navigation.rs
@@ -42,11 +42,12 @@ impl App {
         }
     }
 
-    /// Switch between preview and diff tabs
+    /// Switch between detail pane tabs (forward)
     pub fn switch_tab(&mut self) {
         self.data.active_tab = match self.data.active_tab {
             Tab::Preview => Tab::Diff,
-            Tab::Diff => Tab::Preview,
+            Tab::Diff => Tab::Commits,
+            Tab::Commits => Tab::Preview,
         };
         self.reset_scroll();
     }

--- a/src/app/state/scroll.rs
+++ b/src/app/state/scroll.rs
@@ -14,6 +14,7 @@ impl App {
         match self.data.active_tab {
             Tab::Preview => self.data.ui.scroll_preview_up(amount),
             Tab::Diff => self.data.ui.scroll_diff_up(amount),
+            Tab::Commits => self.data.ui.scroll_commits_up(amount),
         }
     }
 
@@ -22,6 +23,7 @@ impl App {
         match self.data.active_tab {
             Tab::Preview => self.data.ui.scroll_preview_down(amount),
             Tab::Diff => self.data.ui.scroll_diff_down(amount),
+            Tab::Commits => self.data.ui.scroll_commits_down(amount),
         }
     }
 
@@ -30,6 +32,7 @@ impl App {
         match self.data.active_tab {
             Tab::Preview => self.data.ui.preview_to_top(),
             Tab::Diff => self.data.ui.diff_to_top(),
+            Tab::Commits => self.data.ui.commits_to_top(),
         }
     }
 
@@ -38,6 +41,7 @@ impl App {
         match self.data.active_tab {
             Tab::Preview => self.data.ui.preview_to_bottom(content_lines, visible_lines),
             Tab::Diff => self.data.ui.diff_to_bottom(content_lines, visible_lines),
+            Tab::Commits => self.data.ui.commits_to_bottom(content_lines, visible_lines),
         }
     }
 

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -70,6 +70,9 @@ fn test_switch_tab() {
     assert_eq!(app.data.active_tab, Tab::Diff);
 
     app.switch_tab();
+    assert_eq!(app.data.active_tab, Tab::Commits);
+
+    app.switch_tab();
     assert_eq!(app.data.active_tab, Tab::Preview);
 }
 
@@ -149,6 +152,7 @@ fn test_handle_backspace() {
 fn test_tab_display() {
     assert_eq!(format!("{}", Tab::Preview), "Preview");
     assert_eq!(format!("{}", Tab::Diff), "Diff");
+    assert_eq!(format!("{}", Tab::Commits), "Commits");
 }
 
 #[test]

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -21,7 +21,7 @@ pub enum Action {
     RenameBranch,
     /// Open pull request (push first if needed)
     OpenPR,
-    /// Switch between preview/diff tabs
+    /// Switch between detail pane tabs
     SwitchTab,
     /// Move the diff cursor up (Diff tab)
     DiffCursorUp,
@@ -372,7 +372,7 @@ impl Action {
             Self::Push => "[Ctrl+p]ush branch to remote",
             Self::RenameBranch => "[r]ename branch",
             Self::OpenPR => "[Ctrl+o]pen pull request",
-            Self::SwitchTab => "[Tab] switch preview/diff",
+            Self::SwitchTab => "[Tab] next tab",
             Self::DiffCursorUp => "[↑] diff cursor up",
             Self::DiffCursorDown => "[↓] diff cursor down",
             Self::DiffToggleVisual => "[shift+v] block select/unselect",
@@ -383,8 +383,8 @@ impl Action {
             Self::PrevAgent => "[↑] prev agent",
             Self::Help => "[?] help",
             Self::Quit => "[Ctrl+q]uit",
-            Self::ScrollUp => "[Ctrl+u] scroll preview/diff up",
-            Self::ScrollDown => "[Ctrl+d] scroll preview/diff down",
+            Self::ScrollUp => "[Ctrl+u] scroll preview/diff/commits up",
+            Self::ScrollDown => "[Ctrl+d] scroll preview/diff/commits down",
             Self::ScrollTop => "[g]o to top",
             Self::ScrollBottom => "[G]o to bottom",
             Self::Cancel => "Cancel",

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -215,6 +215,9 @@ fn run_loop(
     // Diff refresh is expensive; throttle tick-based updates.
     let diff_refresh_interval = Duration::from_millis(1000);
     let mut last_diff_update = Instant::now();
+    // Commits refresh is cheap; still throttle tick-based updates.
+    let commits_refresh_interval = Duration::from_millis(1000);
+    let mut last_commits_update = Instant::now();
     let mut last_status_sync = Instant::now();
 
     loop {
@@ -284,6 +287,16 @@ fn run_loop(
                 let _ = action_handler.update_diff_digest(app);
             }
             last_diff_update = Instant::now();
+        }
+
+        let commits_due = last_commits_update.elapsed() >= commits_refresh_interval;
+        if needs_content_update || commits_due {
+            if app.data.active_tab == Tab::Commits {
+                let _ = action_handler.update_commits(app);
+            } else {
+                let _ = action_handler.update_commits_digest(app);
+            }
+            last_commits_update = Instant::now();
         }
 
         needs_content_update = false;


### PR DESCRIPTION
Fixes #13

- Adds a Commits tab that shows only base..HEAD for the selected agent branch.
- Shows rich commit metadata and commit body.
- Displays an unseen indicator when new commits arrive.