### PR TITLE
Fix Claude Code broadcast submit + pane activity indicators

### DIFF
--- a/src/agent/status.rs
+++ b/src/agent/status.rs
@@ -32,7 +32,7 @@ impl Status {
     pub const fn symbol(&self) -> &'static str {
         match self {
             Self::Starting => "...",
-            Self::Running => ">>>",
+            Self::Running => "●",
         }
     }
 
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn test_symbol() {
         assert_eq!(Status::Starting.symbol(), "...");
-        assert_eq!(Status::Running.symbol(), ">>>");
+        assert_eq!(Status::Running.symbol(), "●");
     }
 
     #[test]

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -110,6 +110,21 @@ fn test_status_handling() {
 }
 
 #[test]
+fn test_ui_pane_activity_observation() {
+    let mut ui = UiState::new();
+    let id = uuid::Uuid::new_v4();
+
+    ui.observe_agent_pane_digest(id, 42);
+    assert!(!ui.agent_is_waiting_for_input(id));
+
+    ui.observe_agent_pane_digest(id, 42);
+    assert!(ui.agent_is_waiting_for_input(id));
+
+    ui.observe_agent_pane_digest(id, 43);
+    assert!(!ui.agent_is_waiting_for_input(id));
+}
+
+#[test]
 fn test_handle_char() {
     let mut app = App::default();
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -32,6 +32,7 @@ const UI_FRAME_INTERVAL_MS: u64 = 33;
 const PREVIEW_SMOOTH_REFRESH_MS: u64 = 33;
 const AGENT_STATUS_SYNC_INTERVAL_MS: u64 = 500;
 const MIN_OUTPUT_REFRESH_MS: u64 = 16;
+const MIN_PANE_ACTIVITY_SYNC_MS: u64 = 500;
 
 type TuiTerminal = Terminal<CrosstermBackend<io::Stdout>>;
 type DrainedEvents = (Vec<String>, Option<(u16, u16)>, bool);
@@ -216,6 +217,7 @@ fn run_loop(
     let diff_refresh_interval = Duration::from_millis(1000);
     let mut last_diff_update = Instant::now();
     let mut last_status_sync = Instant::now();
+    let mut last_pane_activity_sync = Instant::now();
 
     loop {
         // If we returned to normal mode and still need to show the keyboard prompt,
@@ -247,6 +249,11 @@ fn run_loop(
         if app.data.selected != last_selected {
             last_selected = app.data.selected;
             needs_content_update = true;
+
+            // Treat selecting an agent as "checking" its output for the unseen-waiting indicator.
+            if let Some(agent_id) = app.selected_agent().map(|agent| agent.id) {
+                app.data.ui.mark_agent_pane_seen(agent_id);
+            }
         }
         // Detect tab change
         if app.data.active_tab != last_tab {
@@ -290,6 +297,18 @@ fn run_loop(
 
         // Draw ONCE after draining all queued events
         terminal.draw(|frame| render::render(frame, app))?;
+
+        // Diff-check each pane less frequently than the UI frame rate.
+        let pane_activity_interval = Duration::from_millis(
+            app.data
+                .config
+                .poll_interval_ms
+                .max(MIN_PANE_ACTIVITY_SYNC_MS),
+        );
+        if last_pane_activity_sync.elapsed() >= pane_activity_interval {
+            let _ = action_handler.sync_agent_pane_activity(app);
+            last_pane_activity_sync = Instant::now();
+        }
 
         // Sync agent status less frequently (session listing is relatively expensive).
         if last_status_sync.elapsed() >= Duration::from_millis(AGENT_STATUS_SYNC_INTERVAL_MS) {

--- a/src/tui/render/colors.rs
+++ b/src/tui/render/colors.rs
@@ -21,6 +21,7 @@ pub const TEXT_MUTED: Color = Color::Rgb(100, 122, 150);
 // Status (semantic)
 pub const STATUS_RUNNING: Color = Color::Rgb(0, 220, 140);
 pub const STATUS_STARTING: Color = Color::Rgb(255, 200, 60);
+pub const STATUS_WAITING: Color = Color::Rgb(255, 90, 90);
 
 // Diff
 pub const DIFF_ADD: Color = Color::Rgb(0, 200, 120);

--- a/src/tui/render/main_layout.rs
+++ b/src/tui/render/main_layout.rs
@@ -40,9 +40,19 @@ pub fn render_agent_list(frame: &mut Frame<'_>, app: &App, area: Rect) {
         .iter()
         .enumerate()
         .map(|(i, info)| {
-            let status_color = match info.agent.status {
-                Status::Starting => colors::STATUS_STARTING,
-                Status::Running => colors::STATUS_RUNNING,
+            let (status_symbol, status_color) = match info.agent.status {
+                Status::Starting => (info.agent.status.symbol(), colors::STATUS_STARTING),
+                Status::Running => {
+                    if app.data.ui.agent_is_waiting_for_input(info.agent.id) {
+                        if app.data.ui.agent_has_unseen_waiting_output(info.agent.id) {
+                            ("◐", colors::STATUS_STARTING)
+                        } else {
+                            ("○", colors::STATUS_WAITING)
+                        }
+                    } else {
+                        (info.agent.status.symbol(), colors::STATUS_RUNNING)
+                    }
+                }
             };
 
             let style = if i == app.data.selected {
@@ -74,7 +84,7 @@ pub fn render_agent_list(frame: &mut Frame<'_>, app: &App, area: Rect) {
             let content = Line::from(vec![
                 Span::raw(indent),
                 Span::styled(
-                    format!("{} ", info.agent.status.symbol()),
+                    format!("{status_symbol} "),
                     Style::default().fg(status_color),
                 ),
                 Span::styled(collapse_indicator, Style::default().fg(colors::TEXT_DIM)),

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -678,6 +678,71 @@ mod tests {
     }
 
     #[test]
+    fn test_render_waiting_indicator_renders_unseen_waiting_half_moon()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend)?;
+        let mut app = create_test_app_with_agents();
+
+        let waiting_id = app
+            .data
+            .storage
+            .iter()
+            .find(|agent| agent.title == "agent-1")
+            .map(|agent| agent.id)
+            .ok_or("missing agent-1")?;
+
+        app.data.ui.observe_agent_pane_digest(waiting_id, 123);
+        app.data.ui.observe_agent_pane_digest(waiting_id, 123);
+
+        terminal.draw(|frame| {
+            render(frame, &app);
+        })?;
+
+        let buffer = terminal.backend().buffer();
+        let mut text = String::new();
+        for cell in &buffer.content {
+            text.push_str(cell.symbol());
+        }
+
+        assert!(text.contains("◐"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_render_waiting_indicator_renders_seen_waiting_circle()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend)?;
+        let mut app = create_test_app_with_agents();
+
+        let waiting_id = app
+            .data
+            .storage
+            .iter()
+            .find(|agent| agent.title == "agent-1")
+            .map(|agent| agent.id)
+            .ok_or("missing agent-1")?;
+
+        app.data.ui.observe_agent_pane_digest(waiting_id, 123);
+        app.data.ui.observe_agent_pane_digest(waiting_id, 123);
+        app.data.ui.mark_agent_pane_seen(waiting_id);
+
+        terminal.draw(|frame| {
+            render(frame, &app);
+        })?;
+
+        let buffer = terminal.backend().buffer();
+        let mut text = String::new();
+        for cell in &buffer.content {
+            text.push_str(cell.symbol());
+        }
+
+        assert!(text.contains("○"));
+        Ok(())
+    }
+
+    #[test]
     fn test_render_agent_list_scrollbar_and_hierarchy_indicators()
     -> Result<(), Box<dyn std::error::Error>> {
         let backend = TestBackend::new(80, 12);


### PR DESCRIPTION
## Summary

This fixes a regression where the `broadcast` command for Claude Code would only insert a newline instead of actually submitting the prompt.

It also refines the agent activity indicators and reduces UI jitter:
- `●` (green): working (pane output changing)
- `◐` (yellow): waiting *and unseen* (needs attention)
- `○` (red): waiting (already seen)

Pane activity polling is throttled to **500ms**.

## Root cause (Claude Code submit)

Claude Code submits on **CSI-u Enter** (`ESC [ 13 ; 1 u`), and it only works reliably when that sequence arrives as its **own PTY read chunk**. Sending prompt text + CSI-u Enter in a single write causes Claude to miss the submit.

Fix: for `claude`, submit is sent as two writes (text, then CSI-u Enter) with a short delay.

## Implementation notes

- Adds per-agent pane digest tracking to detect when output is changing vs stalled.
- Tracks “last seen” digests to surface a distinct unseen-waiting state.
- Fixes the agent list alignment so the status glyph doesn’t create large gaps.

## Tests

- Adds a regression test that enforces CSI-u Enter is received as its own chunk.
- Adds an integration test for pane activity syncing + unseen waiting detection.
- Updates render tests for the new glyphs.

Closes #18
