### PR TITLE
Fix preview scrolling UX and performance

### DIFF
--- a/src/action/navigation.rs
+++ b/src/action/navigation.rs
@@ -335,7 +335,7 @@ mod tests {
         let (mut data, _temp) = create_test_data()?;
 
         data.active_tab = Tab::Preview;
-        data.ui.preview_content = "line1\nline2\nline3\n".to_string();
+        data.ui.set_preview_content("line1\nline2\nline3\n");
         assert_eq!(
             ScrollUpAction.execute(NormalMode, &mut data)?,
             ScrollingMode.into()

--- a/src/app/handlers/preview.rs
+++ b/src/app/handlers/preview.rs
@@ -20,7 +20,7 @@ impl Actions {
         // smaller so we can refresh more frequently without stuttering.
         const HISTORY_LINES_FOLLOWING: u32 = 300;
 
-        let old_line_count = app.data.ui.preview_content.lines().count();
+        let old_line_count = app.data.ui.preview_text.lines.len();
         let old_scroll = app.data.ui.preview_scroll;
         let visible_height = app
             .data
@@ -58,17 +58,21 @@ impl Actions {
                         .capture_pane_with_history(&target, HISTORY_LINES_FOLLOWING)
                         .unwrap_or_default()
                 };
-                app.data.ui.preview_content = content;
+                app.data.ui.set_preview_content(content);
                 app.data.ui.preview_cursor_position =
                     self.output_capture.cursor_position(&target).ok();
                 app.data.ui.preview_pane_size = self.output_capture.pane_size(&target).ok();
             } else {
-                app.data.ui.preview_content = String::from("(Session not running)");
+                app.data
+                    .ui
+                    .set_preview_content(String::from("(Session not running)"));
                 app.data.ui.preview_cursor_position = None;
                 app.data.ui.preview_pane_size = None;
             }
         } else {
-            app.data.ui.preview_content = String::from("(No agent selected)");
+            app.data
+                .ui
+                .set_preview_content(String::from("(No agent selected)"));
             app.data.ui.preview_cursor_position = None;
             app.data.ui.preview_pane_size = None;
         }
@@ -77,7 +81,7 @@ impl Actions {
         // scroll position relative to the bottom of the buffer. Without this, the viewport
         // can appear to "jump" far up because the top of the buffer gained many lines.
         if switching_to_full_history {
-            let new_line_count = app.data.ui.preview_content.lines().count();
+            let new_line_count = app.data.ui.preview_text.lines.len();
 
             let old_max = old_line_count.saturating_sub(visible_height);
             let old_scroll = old_scroll.min(old_max);

--- a/src/app/state/tests.rs
+++ b/src/app/state/tests.rs
@@ -355,7 +355,9 @@ fn test_input_cursor_home_end() {
 #[test]
 fn test_scroll_methods() {
     let mut app = App::default();
-    app.data.ui.preview_content = "line1\nline2\nline3\nline4\nline5".to_string();
+    app.data
+        .ui
+        .set_preview_content("line1\nline2\nline3\nline4\nline5");
     app.data.ui.set_diff_content("diff1\ndiff2\ndiff3");
     app.data.ui.preview_dimensions = Some((80, 2));
 

--- a/src/tui/input/mod.rs
+++ b/src/tui/input/mod.rs
@@ -135,8 +135,13 @@ pub fn handle_key_event(
 /// Handle a mouse event based on the current mode and layout.
 ///
 /// `frame_area` should be the terminal viewport (`Rect::new(0, 0, width, height)`).
-pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, frame_area: Rect) -> Result<()> {
-    mouse::handle_mouse_event(app, mouse, frame_area)
+pub fn handle_mouse_event(
+    app: &mut App,
+    mouse: MouseEvent,
+    frame_area: Rect,
+    batched_keys: &mut Vec<String>,
+) -> Result<()> {
+    mouse::handle_mouse_event(app, mouse, frame_area, batched_keys)
 }
 
 #[cfg(test)]

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -571,7 +571,9 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
         let mut app = create_test_app_with_agents();
-        app.data.ui.preview_content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5".to_string();
+        app.data
+            .ui
+            .set_preview_content("Line 1\nLine 2\nLine 3\nLine 4\nLine 5");
 
         terminal.draw(|frame| {
             render(frame, &app);
@@ -587,10 +589,12 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
         let mut app = create_test_app_with_agents();
-        app.data.ui.preview_content = (0..100)
-            .map(|i| format!("Line {i}"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        app.data.ui.set_preview_content(
+            (0..100)
+                .map(|i| format!("Line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
         app.data.ui.preview_scroll = 50;
 
         terminal.draw(|frame| {
@@ -611,10 +615,12 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
         let mut app = create_test_app_with_agents();
         app.enter_mode(PreviewFocusedMode.into());
-        app.data.ui.preview_content = (0..10)
-            .map(|i| format!("Line {i}"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        app.data.ui.set_preview_content(
+            (0..10)
+                .map(|i| format!("Line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
         app.data.ui.preview_cursor_position = Some((3, 4, false));
         app.data.ui.preview_pane_size = Some((54, 50));
 
@@ -636,10 +642,12 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
         let mut app = create_test_app_with_agents();
         app.enter_mode(PreviewFocusedMode.into());
-        app.data.ui.preview_content = (0..50)
-            .map(|i| format!("Line {i}"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        app.data.ui.set_preview_content(
+            (0..50)
+                .map(|i| format!("Line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
         app.data.ui.preview_scroll = 16;
         app.data.ui.preview_cursor_position = Some((7, 5, false));
         app.data.ui.preview_pane_size = Some((54, 20));
@@ -883,7 +891,7 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
         let mut app = create_test_app_with_agents();
-        app.data.ui.preview_content = "Line 1\nLine 2".to_string();
+        app.data.ui.set_preview_content("Line 1\nLine 2");
         // Set scroll position beyond content length
         app.data.ui.preview_scroll = 1000;
 


### PR DESCRIPTION
### What
- Preview stays scrollable while attached; Alt+wheel forwards scroll to Codex
- Avoids lag by pausing tick-based preview recapture when scrolled up (not following)
- Caches ANSI→Text parsing and renders only visible lines
- Hides preview scrollbar while following; shows it when paused
- Adds regression tests

### Tests
- cargo test (via pre-commit hook)
