### PR TITLE
Release v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.7] - 2026-01-19
+
+### Fixed
+
+- **Mux daemon upgrades**: Tenex now detects when an older `tenex muxd` is still running after an upgrade and prompts you to restart it.
+
 ## [1.0.6] - 2026-01-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "tenex"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tenex"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 rust-version = "1.91"
 resolver = "3"


### PR DESCRIPTION
- Bump Tenex to v1.0.7
- Changelog: prompt to restart an outdated mux daemon after upgrade