### PR TITLE
Fix #106: isolate pre-commit muxd cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,12 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: precommit-hook-unit-tests
+        name: pre-commit hook unit tests
+        entry: python3 scripts/precommit/test_run_cargo_hook.py
+        language: system
+        pass_filenames: false
+
       - id: cargo-test
         name: cargo test
         entry: python3 scripts/precommit/run_cargo_hook.py test

--- a/scripts/precommit/run_cargo_hook.py
+++ b/scripts/precommit/run_cargo_hook.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -19,7 +20,8 @@ def repo_root() -> Path:
     return Path(output.strip())
 
 
-def muxd_pids_from_proc(proc_dir: Path, target_prefix: str) -> set[int]:
+def muxd_pids_from_proc(proc_dir: Path, socket: str) -> set[int]:
+    wanted_socket = f"TENEX_MUX_SOCKET={socket}"
     pids: set[int] = set()
     for entry in proc_dir.iterdir():
         if not entry.name.isdigit():
@@ -37,61 +39,60 @@ def muxd_pids_from_proc(proc_dir: Path, target_prefix: str) -> set[int]:
         if not parts:
             continue
 
-        executable = parts[0].replace("\\", "/")
-        if not executable.startswith(target_prefix):
-            continue
         if "muxd" not in parts:
+            continue
+
+        environ_path = entry / "environ"
+        try:
+            environ = environ_path.read_bytes()
+        except OSError:
+            continue
+        if not environ:
+            continue
+
+        env_parts = [part.decode("utf-8", "replace") for part in environ.split(b"\0") if part]
+        if wanted_socket not in env_parts:
             continue
 
         pids.add(int(entry.name))
     return pids
 
 
-def muxd_pids_from_ps(target_prefix: str) -> set[int]:
-    result = subprocess.run(
-        ["ps", "-axo", "pid=,command="],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
+def fnv1a64(value: str) -> int:
+    hash_value = 0xCBF29CE484222325
+    for byte in value.encode("utf-8"):
+        hash_value ^= byte
+        hash_value = (hash_value * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return hash_value
+
+
+def muxd_pidfile_path(state_dir: Path, socket: str) -> Path:
+    return state_dir / f"tenex-muxd-{fnv1a64(socket):016x}.pid"
+
+
+def muxd_pids_from_pidfile(state_dir: Path, socket: str) -> set[int]:
+    pidfile_path = muxd_pidfile_path(state_dir, socket)
+    try:
+        payload = json.loads(pidfile_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
         return set()
 
-    pids: set[int] = set()
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
+    if str(payload.get("socket", "")).strip() != socket:
+        return set()
 
-        fields = line.split(None, 1)
-        if len(fields) != 2:
-            continue
+    pid = payload.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return set()
 
-        pid_str, command = fields
-        if not pid_str.isdigit():
-            continue
-
-        parts = command.split()
-        if not parts:
-            continue
-
-        executable = parts[0].replace("\\", "/")
-        if not executable.startswith(target_prefix):
-            continue
-        if "muxd" not in parts:
-            continue
-
-        pids.add(int(pid_str))
-    return pids
+    return {pid}
 
 
-def cleanup_repo_muxd(root: Path) -> None:
-    target_prefix = (root / "target").as_posix().rstrip("/") + "/"
+def cleanup_hook_muxd(state_dir: Path, socket: str) -> None:
     proc_dir = Path("/proc")
     pids = (
-        muxd_pids_from_proc(proc_dir, target_prefix)
+        muxd_pids_from_proc(proc_dir, socket)
         if proc_dir.is_dir()
-        else muxd_pids_from_ps(target_prefix)
+        else muxd_pids_from_pidfile(state_dir, socket)
     )
 
     if not pids:
@@ -209,11 +210,12 @@ def main() -> int:
         shutil.rmtree(root / "target" / "llvm-cov-target", ignore_errors=True)
 
     state_dir = Path(tempfile.mkdtemp(prefix="tenex-pre-commit-"))
+    mux_socket = str(state_dir / "mux.sock")
     env = os.environ.copy()
     env["TENEX_STATE_PATH"] = str(state_dir / "state.json")
-    env["TENEX_MUX_SOCKET"] = str(state_dir / "mux.sock")
+    env["TENEX_MUX_SOCKET"] = mux_socket
 
-    cleanup_repo_muxd(root)
+    cleanup_hook_muxd(state_dir, mux_socket)
     try:
         command = build_command(args.mode)
         result = subprocess.run(
@@ -224,7 +226,7 @@ def main() -> int:
         )
         return result.returncode
     finally:
-        cleanup_repo_muxd(root)
+        cleanup_hook_muxd(state_dir, mux_socket)
         shutil.rmtree(state_dir, ignore_errors=True)
 
 

--- a/scripts/precommit/test_run_cargo_hook.py
+++ b/scripts/precommit/test_run_cargo_hook.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_module():
+    path = Path(__file__).with_name("run_cargo_hook.py")
+    spec = importlib.util.spec_from_file_location("run_cargo_hook", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+run_cargo_hook = load_module()
+
+
+class RunCargoHookTests(unittest.TestCase):
+    def test_muxd_pids_from_proc_matches_exact_socket(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc_root = Path(tmp)
+
+            matching = proc_root / "100"
+            matching.mkdir()
+            (matching / "cmdline").write_bytes(b"/repo/target/debug/tenex\0muxd\0")
+            (matching / "environ").write_bytes(
+                b"TENEX_MUX_SOCKET=/tmp/live.sock\0TENEX_STATE_PATH=/tmp/state.json\0"
+            )
+
+            wrong_socket = proc_root / "101"
+            wrong_socket.mkdir()
+            (wrong_socket / "cmdline").write_bytes(b"/repo/target/debug/tenex\0muxd\0")
+            (wrong_socket / "environ").write_bytes(b"TENEX_MUX_SOCKET=/tmp/other.sock\0")
+
+            not_muxd = proc_root / "102"
+            not_muxd.mkdir()
+            (not_muxd / "cmdline").write_bytes(b"/repo/target/debug/tenex\0test\0")
+            (not_muxd / "environ").write_bytes(b"TENEX_MUX_SOCKET=/tmp/live.sock\0")
+
+            pids = run_cargo_hook.muxd_pids_from_proc(proc_root, "/tmp/live.sock")
+            self.assertEqual(pids, {100})
+
+    def test_muxd_pids_from_pidfile_matches_exact_socket(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp)
+            pidfile = run_cargo_hook.muxd_pidfile_path(state_dir, "/tmp/live.sock")
+            pidfile.write_text(
+                json.dumps({"pid": 321, "socket": "/tmp/live.sock"}),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                run_cargo_hook.muxd_pids_from_pidfile(state_dir, "/tmp/live.sock"),
+                {321},
+            )
+            self.assertEqual(
+                run_cargo_hook.muxd_pids_from_pidfile(state_dir, "/tmp/other.sock"),
+                set(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- clean up only the hook-owned mux daemon by exact `TENEX_MUX_SOCKET`
- use `/proc` environment matching on Linux and WSL2 and pidfile matching on non-`/proc` platforms
- add a pre-commit unit test hook for the cleanup targeting logic

## Testing
- `python3 scripts/precommit/test_run_cargo_hook.py`
- `bash repro/run.sh`
- `pre-commit run --all-files`
- macOS repro before/after plus full pre-commit and coverage export
- Windows WSL2 repro before/after plus full pre-commit and coverage export

Fixes #106