### PR TITLE
Enable tracing std for cargo install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "std"
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 anyhow = { version = "1.0", default-features = false, features = ["std"] }
 thiserror = { version = "2.0", default-features = false }
-tracing = { version = "0.1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "std", "fmt"] }
 tracing-appender = { version = "0.2", default-features = false }
 uuid = { version = "1.19", default-features = false, features = ["v4", "serde", "std"] }


### PR DESCRIPTION
This fixes cargo install --path . after the mux reader thread started using tracing::dispatcher::with_default in production code. That API is gated behind tracing's std feature, so the direct dependency now enables std explicitly.\n\nValidated with:\n- CARGO_INSTALL_ROOT=$(mktemp -d) cargo install --path .\n- cargo fmt --all --check\n- git diff --check\n- cargo clippy --all-targets --all-features -- -D warnings