### PR TITLE
Fix Codex review base branch selection

### DIFF
--- a/src/app/handlers/swarm.rs
+++ b/src/app/handlers/swarm.rs
@@ -50,8 +50,21 @@ const CODEX_REVIEW_BASE_BRANCH_TIMEOUT: &str =
     "Timed out waiting for Codex /review base branch prompt; leaving agent for manual review";
 const CODEX_REVIEW_START_TIMEOUT: &str =
     "Timed out waiting for Codex /review to start; leaving agent for manual review";
+const CODEX_REVIEW_BASE_BRANCH_MISMATCH_STATUS: &str =
+    "Codex review may be running against a different base than requested";
 const SYNTHESIS_KILL_WINDOW_WARN: &str =
     "Failed to kill descendant mux window during synthesis cleanup";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CodexReviewStart {
+    NotObserved,
+    MatchedBaseBranch,
+    BaseBranchMismatch,
+}
+
+fn codex_review_base_branch_hint(base_branch: &str) -> String {
+    format!("changes against '{base_branch}'")
+}
 
 #[cfg(any(test, coverage))]
 thread_local! {
@@ -417,7 +430,7 @@ impl Actions {
         Ok(synthesis_file)
     }
 
-    fn start_codex_review_flow(self, target: &str, base_branch: &str) -> Result<()> {
+    fn start_codex_review_flow(self, target: &str, base_branch: &str) -> Result<CodexReviewStart> {
         self.start_codex_review_flow_with_timings(
             target,
             base_branch,
@@ -431,7 +444,7 @@ impl Actions {
         target: &str,
         base_branch: &str,
         timings: CodexReviewTimings,
-    ) -> Result<()> {
+    ) -> Result<CodexReviewStart> {
         let base_branch = base_branch.trim();
         if base_branch.is_empty() {
             bail!("Base branch cannot be empty for Codex review flow");
@@ -443,7 +456,7 @@ impl Actions {
 
         if !self.wait_for_pane_idle(target, idle_stable_for, step_timeout, poll_interval) {
             warn!(target, "{}", CODEX_PANE_SETTLE_TIMEOUT);
-            return Ok(());
+            return Ok(CodexReviewStart::NotObserved);
         }
 
         self.session_manager.send_keys(target, "/review")?;
@@ -462,20 +475,20 @@ impl Actions {
             poll_interval,
         ) {
             warn!(target, "{}", CODEX_REVIEW_PRESET_TIMEOUT);
-            return Ok(());
+            return Ok(CodexReviewStart::NotObserved);
         }
 
         let _ = self.wait_for_pane_idle(target, idle_stable_for, step_timeout, poll_interval);
         self.session_manager.send_keys_and_submit(target, "")?;
         if !self.wait_for_pane_contains_any(target, &["base branch"], step_timeout, poll_interval) {
             warn!(target, "{}", CODEX_REVIEW_BASE_BRANCH_TIMEOUT);
-            return Ok(());
+            return Ok(CodexReviewStart::NotObserved);
         }
 
         let _ = self.wait_for_pane_idle(target, idle_stable_for, step_timeout, poll_interval);
         self.session_manager.send_keys(target, base_branch)?;
         self.session_manager.send_keys_and_submit(target, "")?;
-        if !self.wait_for_pane_contains_any(
+        let review_start = self.wait_for_pane_contains_any_text(
             target,
             &[
                 "review started",
@@ -484,26 +497,42 @@ impl Actions {
             ],
             step_timeout,
             poll_interval,
-        ) {
+        );
+        let Some(review_start) = review_start else {
             warn!(target, "{}", CODEX_REVIEW_START_TIMEOUT);
+            return Ok(CodexReviewStart::NotObserved);
+        };
+
+        let expected_hint = codex_review_base_branch_hint(base_branch);
+        if !review_start.contains(&expected_hint) {
+            warn!(
+                target,
+                requested_base_branch = base_branch,
+                expected_hint,
+                review_confirmation = %review_start,
+                "Codex /review may have started against a different base branch"
+            );
+            return Ok(CodexReviewStart::BaseBranchMismatch);
         }
 
-        Ok(())
+        Ok(CodexReviewStart::MatchedBaseBranch)
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
-    fn start_codex_review_flows(self, flows: Vec<(String, String)>) {
+    fn start_codex_review_flows(self, flows: Vec<(String, String)>) -> bool {
+        let mut found_mismatch = false;
         for (target, base_branch) in flows {
-            if let Err(err) = self.start_codex_review_flow(&target, &base_branch) {
-                warn!(target, error = %err, "Failed to drive Codex /review flow");
+            match self.start_codex_review_flow(&target, &base_branch) {
+                Ok(CodexReviewStart::BaseBranchMismatch) => {
+                    found_mismatch = true;
+                }
+                Ok(CodexReviewStart::NotObserved | CodexReviewStart::MatchedBaseBranch) => {}
+                Err(err) => {
+                    warn!(target, error = %err, "Failed to drive Codex /review flow");
+                }
             }
         }
-    }
-
-    fn start_codex_review_flows_in_background(self, flows: Vec<(String, String)>) {
-        std::thread::spawn(move || {
-            self.start_codex_review_flows(flows);
-        });
+        found_mismatch
     }
 
     fn codex_review_flow_for_child(child: &Agent, base_branch: &str) -> Option<(String, String)> {
@@ -525,16 +554,27 @@ impl Actions {
         timeout: Duration,
         poll_interval: Duration,
     ) -> bool {
+        self.wait_for_pane_contains_any_text(target, needles, timeout, poll_interval)
+            .is_some()
+    }
+
+    fn wait_for_pane_contains_any_text(
+        self,
+        target: &str,
+        needles: &[&str],
+        timeout: Duration,
+        poll_interval: Duration,
+    ) -> Option<String> {
         let start = Instant::now();
         while start.elapsed() < timeout {
             if let Ok(pane) = self.output_capture.capture_pane(target)
                 && needles.iter().any(|needle| pane.contains(needle))
             {
-                return true;
+                return Some(pane);
             }
             std::thread::sleep(poll_interval);
         }
-        false
+        None
     }
 
     fn wait_for_pane_idle(
@@ -1040,7 +1080,12 @@ impl Actions {
         app_data.review.clear();
 
         if !codex_review_flows.is_empty() {
-            self.start_codex_review_flows_in_background(codex_review_flows);
+            let found_mismatch = self.start_codex_review_flows(codex_review_flows);
+            if found_mismatch {
+                app_data.set_status(format!(
+                    "{CODEX_REVIEW_BASE_BRANCH_MISMATCH_STATUS}: {base_branch}"
+                ));
+            }
         }
 
         Ok(())
@@ -1239,6 +1284,39 @@ mod tests {
             .finish();
         let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
         tracing::dispatcher::with_default(&dispatch, f)
+    }
+
+    #[derive(Clone)]
+    struct SharedTraceWriter {
+        buffer: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    }
+
+    impl std::io::Write for SharedTraceWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.buffer.lock().expect("lock").extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn with_captured_tracing<T>(f: impl FnOnce() -> T) -> (T, String) {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let writer = SharedTraceWriter {
+            buffer: std::sync::Arc::clone(&buffer),
+        };
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_writer(move || writer.clone())
+            .with_max_level(tracing::Level::TRACE)
+            .finish();
+        let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
+        let result = tracing::dispatcher::with_default(&dispatch, f);
+        let bytes = buffer.lock().expect("lock").clone();
+        let logs = String::from_utf8(bytes).expect("trace logs utf8");
+        (result, logs)
     }
 
     #[test]
@@ -1581,7 +1659,7 @@ mod tests {
             "review my current changes",
             "review preset",
             "base branch",
-            "review started",
+            ">> Code review started: changes against 'main' <<",
         ]
         .join("\n");
 
@@ -1614,7 +1692,7 @@ mod tests {
             "review my current changes",
             "review preset",
             "base branch",
-            "review started",
+            ">> Code review started: changes against 'stage' <<",
         ]
         .join("\n");
 
@@ -1629,9 +1707,10 @@ mod tests {
             command_hint_timeout: Duration::from_millis(50),
         };
 
-        handler
+        let review_start = handler
             .start_codex_review_flow_with_timings("session", "stage", timings)
             .expect("review flow should succeed");
+        assert_eq!(review_start, CodexReviewStart::MatchedBaseBranch);
 
         server.join().expect("mock mux server panicked");
         let inputs = captured_inputs.lock().expect("lock");
@@ -1641,6 +1720,52 @@ mod tests {
         assert_eq!(inputs[2], b"\r");
         assert_eq!(inputs[3], b"stage");
         assert_eq!(inputs[4], b"\r");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_start_codex_review_flow_warns_when_confirmation_names_different_base_branch() {
+        let _mux_guard = crate::test_support::lock_mux_test_environment();
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let (display, name) = make_mock_socket(&temp);
+        crate::mux::set_socket_override(&display).expect("set socket override");
+
+        let capture_text = [
+            "review my current changes",
+            "review preset",
+            "base branch",
+            ">> Code review started: changes against 'feature/stage' <<",
+        ]
+        .join("\n");
+
+        let (server, captured_inputs) =
+            spawn_capturing_mock_mux_server(name, capture_text, Vec::new(), 15);
+
+        let handler = Actions::new();
+        let timings = CodexReviewTimings {
+            poll_interval: Duration::from_millis(1),
+            step_timeout: Duration::from_millis(250),
+            idle_stable_for: Duration::from_millis(0),
+            command_hint_timeout: Duration::from_millis(50),
+        };
+
+        let (result, logs) = with_captured_tracing(|| {
+            handler.start_codex_review_flow_with_timings("session", "stage", timings)
+        });
+
+        assert_eq!(
+            result.expect("review flow should succeed"),
+            CodexReviewStart::BaseBranchMismatch
+        );
+        assert!(
+            logs.contains("Codex /review may have started against a different base branch"),
+            "expected mismatch warning in logs, got: {logs:?}"
+        );
+
+        server.join().expect("mock mux server panicked");
+        let inputs = captured_inputs.lock().expect("lock");
+        assert_eq!(inputs.len(), 5);
+        assert_eq!(inputs[3], b"stage");
     }
 
     #[cfg(unix)]

--- a/src/app/handlers/swarm.rs
+++ b/src/app/handlers/swarm.rs
@@ -473,7 +473,7 @@ impl Actions {
         }
 
         let _ = self.wait_for_pane_idle(target, idle_stable_for, step_timeout, poll_interval);
-        self.session_manager.paste_keys(target, base_branch)?;
+        self.session_manager.send_keys(target, base_branch)?;
         self.session_manager.send_keys_and_submit(target, "")?;
         if !self.wait_for_pane_contains_any(
             target,
@@ -1476,12 +1476,26 @@ mod tests {
     }
 
     #[cfg(unix)]
+    type CapturedInputs = std::sync::Arc<std::sync::Mutex<Vec<Vec<u8>>>>;
+
+    #[cfg(unix)]
     fn spawn_mock_mux_server(
         name: interprocess::local_socket::Name<'static>,
         capture_text: String,
         send_input_responses: Vec<crate::mux::MuxResponse>,
         expected_requests: usize,
     ) -> std::thread::JoinHandle<()> {
+        spawn_capturing_mock_mux_server(name, capture_text, send_input_responses, expected_requests)
+            .0
+    }
+
+    #[cfg(unix)]
+    fn spawn_capturing_mock_mux_server(
+        name: interprocess::local_socket::Name<'static>,
+        capture_text: String,
+        send_input_responses: Vec<crate::mux::MuxResponse>,
+        expected_requests: usize,
+    ) -> (std::thread::JoinHandle<()>, CapturedInputs) {
         use crate::mux::{MuxRequest, MuxResponse};
 
         let listener = ListenerOptions::new()
@@ -1489,8 +1503,10 @@ mod tests {
             .create_sync()
             .expect("Expected mock mux listener to start");
         let send_input_counter = AtomicUsize::new(0);
+        let captured_inputs = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured_inputs_server = std::sync::Arc::clone(&captured_inputs);
 
-        std::thread::spawn(move || {
+        let server = std::thread::spawn(move || {
             let mut handled = 0usize;
             for mut stream in listener.incoming().flatten() {
                 while handled < expected_requests {
@@ -1502,7 +1518,8 @@ mod tests {
                         MuxRequest::Capture { .. } => MuxResponse::Text {
                             text: capture_text.clone(),
                         },
-                        MuxRequest::SendInput { .. } => {
+                        MuxRequest::SendInput { data, .. } => {
+                            captured_inputs_server.lock().expect("lock").push(data);
                             let idx = send_input_counter.fetch_add(1, Ordering::SeqCst);
                             send_input_responses
                                 .get(idx)
@@ -1522,7 +1539,9 @@ mod tests {
                     break;
                 }
             }
-        })
+        });
+
+        (server, captured_inputs)
     }
 
     fn require_mux_err_response(
@@ -1581,6 +1600,47 @@ mod tests {
             .expect("review flow should succeed");
 
         server.join().expect("mock mux server panicked");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_start_codex_review_flow_types_base_branch_without_bracketed_paste() {
+        let _mux_guard = crate::test_support::lock_mux_test_environment();
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let (display, name) = make_mock_socket(&temp);
+        crate::mux::set_socket_override(&display).expect("set socket override");
+
+        let capture_text = [
+            "review my current changes",
+            "review preset",
+            "base branch",
+            "review started",
+        ]
+        .join("\n");
+
+        let (server, captured_inputs) =
+            spawn_capturing_mock_mux_server(name, capture_text, Vec::new(), 15);
+
+        let handler = Actions::new();
+        let timings = CodexReviewTimings {
+            poll_interval: Duration::from_millis(1),
+            step_timeout: Duration::from_millis(250),
+            idle_stable_for: Duration::from_millis(0),
+            command_hint_timeout: Duration::from_millis(50),
+        };
+
+        handler
+            .start_codex_review_flow_with_timings("session", "stage", timings)
+            .expect("review flow should succeed");
+
+        server.join().expect("mock mux server panicked");
+        let inputs = captured_inputs.lock().expect("lock");
+        assert_eq!(inputs.len(), 5);
+        assert_eq!(inputs[0], b"/review");
+        assert_eq!(inputs[1], b"\r");
+        assert_eq!(inputs[2], b"\r");
+        assert_eq!(inputs[3], b"stage");
+        assert_eq!(inputs[4], b"\r");
     }
 
     #[cfg(unix)]
@@ -1703,7 +1763,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_start_codex_review_flow_propagates_paste_errors() {
+    fn test_start_codex_review_flow_propagates_base_branch_send_errors() {
         let _mux_guard = crate::test_support::lock_mux_test_environment();
         let temp = tempfile::TempDir::new().expect("tempdir");
         let (display, name) = make_mock_socket(&temp);
@@ -1722,7 +1782,7 @@ mod tests {
             crate::mux::MuxResponse::Ok,
             crate::mux::MuxResponse::Ok,
             crate::mux::MuxResponse::Err {
-                message: "paste failed".to_string(),
+                message: "base branch send failed".to_string(),
             },
         ];
         let server = spawn_mock_mux_server(name, capture_text, send_input_responses, 13);
@@ -1737,15 +1797,15 @@ mod tests {
 
         let err = handler
             .start_codex_review_flow_with_timings("session", "main", timings)
-            .expect_err("expected paste_keys to error");
-        assert!(err.to_string().contains("paste failed"));
+            .expect_err("expected base branch send_keys to error");
+        assert!(err.to_string().contains("base branch send failed"));
 
         server.join().expect("mock mux server panicked");
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_start_codex_review_flow_propagates_submit_after_paste_errors() {
+    fn test_start_codex_review_flow_propagates_submit_after_base_branch_errors() {
         let _mux_guard = crate::test_support::lock_mux_test_environment();
         let temp = tempfile::TempDir::new().expect("tempdir");
         let (display, name) = make_mock_socket(&temp);
@@ -1765,7 +1825,7 @@ mod tests {
             crate::mux::MuxResponse::Ok,
             crate::mux::MuxResponse::Ok,
             crate::mux::MuxResponse::Err {
-                message: "submit after paste failed".to_string(),
+                message: "submit after base branch failed".to_string(),
             },
         ];
         let server = spawn_mock_mux_server(name, capture_text, send_input_responses, 14);
@@ -1780,8 +1840,8 @@ mod tests {
 
         let err = handler
             .start_codex_review_flow_with_timings("session", "main", timings)
-            .expect_err("expected send_keys_and_submit after paste to error");
-        assert!(err.to_string().contains("submit after paste failed"));
+            .expect_err("expected send_keys_and_submit after base branch to error");
+        assert!(err.to_string().contains("submit after base branch failed"));
 
         server.join().expect("mock mux server panicked");
     }

--- a/src/mux/session.rs
+++ b/src/mux/session.rs
@@ -202,19 +202,6 @@ impl Manager {
         self.send_input_bytes(target, &payload)
     }
 
-    /// Paste keys to a target (bracketed paste).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if keys cannot be pasted.
-    pub fn paste_keys(&self, target: &str, keys: &str) -> Result<()> {
-        let mut payload = Vec::with_capacity(keys.len() + 16);
-        payload.extend_from_slice(b"\x1b[200~");
-        payload.extend_from_slice(keys.as_bytes());
-        payload.extend_from_slice(b"\x1b[201~");
-        self.send_input_bytes(target, &payload)
-    }
-
     /// Send input to an agent program, using a program-specific strategy.
     ///
     /// # Errors

--- a/tests/integration/review.rs
+++ b/tests/integration/review.rs
@@ -85,6 +85,9 @@ while True:
         buffer.pop()
         continue
 
+    if in_paste and state == 2:
+        continue
+
     buffer += ch
     if state == 0 and not in_paste and not hint_shown and buffer == b"/review":
         print("  /review  review my current changes and find issues", flush=True)
@@ -415,7 +418,8 @@ fn test_spawn_review_agents() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 #[cfg(unix)]
-fn test_spawn_review_agents_codex_uses_review_flow() -> Result<(), Box<dyn std::error::Error>> {
+fn test_spawn_review_agents_codex_selects_typed_base_branch()
+-> Result<(), Box<dyn std::error::Error>> {
     if skip_if_no_mux() {
         return Ok(());
     }
@@ -458,7 +462,7 @@ fn test_spawn_review_agents_codex_uses_review_flow() -> Result<(), Box<dyn std::
 
     app.data.spawn.spawning_under = Some(root_id);
     app.data.spawn.child_count = 1;
-    app.data.review.base_branch = Some("master".to_string());
+    app.data.review.base_branch = Some("stage".to_string());
 
     let result = handler.spawn_review_agents(&mut app.data);
 
@@ -507,8 +511,8 @@ fn test_spawn_review_agents_codex_uses_review_flow() -> Result<(), Box<dyn std::
             "Expected Codex review agents to type /review, got: {output:?}"
         );
         assert!(
-            output.contains("master"),
-            "Expected Codex review agents to enter the base branch, got: {output:?}"
+            output.contains("'stage'") && !output.contains("'master'"),
+            "Expected Codex review agents to start against the selected branch, got: {output:?}"
         );
         assert!(
             output.contains("review started"),
@@ -528,21 +532,25 @@ fn test_spawn_review_agents_codex_uses_review_flow() -> Result<(), Box<dyn std::
 
 #[test]
 #[cfg(not(unix))]
-fn test_spawn_review_agents_codex_uses_review_flow() {}
+fn test_spawn_review_agents_codex_selects_typed_base_branch() {}
 
 #[test]
 fn test_review_prompt_contains_base_branch() {
     let prompt = tenex::prompts::build_review_prompt("main");
+    let stage_prompt = tenex::prompts::build_review_prompt("stage");
 
     // Should contain the base branch name
     assert!(prompt.contains("main"));
+    assert!(stage_prompt.contains("stage"));
 
     // Should contain key review instructions
     assert!(prompt.contains("git diff main...HEAD"));
+    assert!(stage_prompt.contains("git diff stage...HEAD"));
     assert!(prompt.contains("git diff --staged"));
     assert!(prompt.contains("git diff"));
     assert!(prompt.contains("git status"));
     assert!(prompt.contains("git log main..HEAD"));
+    assert!(stage_prompt.contains("git log stage..HEAD"));
 
     // Should contain review categories
     assert!(prompt.contains("Code Quality"));

--- a/tests/integration/review.rs
+++ b/tests/integration/review.rs
@@ -15,8 +15,20 @@ import tty
 ENTER_CSI_U = b"\x1b[13;1u"
 PASTE_START = b"\x1b[200~"
 PASTE_END = b"\x1b[201~"
+BRANCHES = [__BRANCH_LIST__]
 
 tty.setraw(sys.stdin.fileno())
+
+
+def selected_branch(text: str) -> str:
+    query = text.strip()
+    if not query:
+        return "master"
+    query_lower = query.lower()
+    for branch in BRANCHES:
+        if query_lower in branch.lower():
+            return branch
+    return "master"
 
 
 def read_escape_sequence() -> bytes:
@@ -44,7 +56,7 @@ def handle_submit(state: int, text: str) -> int:
         print("Select a base branch", flush=True)
         return 2
     if state == 2:
-        branch = text.strip() or "master"
+        branch = selected_branch(text)
         print(f">> Code review started: changes against '{branch}' <<", flush=True)
         return 3
     return state
@@ -93,6 +105,16 @@ while True:
         print("  /review  review my current changes and find issues", flush=True)
         hint_shown = True
 "#;
+
+#[cfg(unix)]
+fn codex_review_flow_mock_script(branches: &[&str]) -> String {
+    let branch_list = branches
+        .iter()
+        .map(|branch| format!("\"{branch}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    CODEX_REVIEW_FLOW_MOCK_SCRIPT.replace("__BRANCH_LIST__", &branch_list)
+}
 
 #[cfg(unix)]
 fn write_executable_script(path: &Path, contents: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -431,7 +453,10 @@ fn test_spawn_review_agents_codex_selects_typed_base_branch()
     let codex_path = fixture.repo_path.join("codex");
     #[cfg(unix)]
     {
-        write_executable_script(&codex_path, CODEX_REVIEW_FLOW_MOCK_SCRIPT)?;
+        write_executable_script(
+            &codex_path,
+            &codex_review_flow_mock_script(&["master", "stage"]),
+        )?;
     }
 
     let settings = tenex::app::Settings {
@@ -533,6 +558,116 @@ fn test_spawn_review_agents_codex_selects_typed_base_branch()
 #[test]
 #[cfg(not(unix))]
 fn test_spawn_review_agents_codex_selects_typed_base_branch() {}
+
+#[test]
+#[cfg(unix)]
+fn test_spawn_review_agents_codex_warns_when_branch_picker_selects_colliding_name()
+-> Result<(), Box<dyn std::error::Error>> {
+    if skip_if_no_mux() {
+        return Ok(());
+    }
+
+    let fixture = TestFixture::new("review_codex_colliding_base")?;
+    let config = fixture.config();
+    let storage = fixture.storage();
+
+    let codex_path = fixture.repo_path.join("codex");
+    write_executable_script(
+        &codex_path,
+        &codex_review_flow_mock_script(&["feature/stage", "stage", "master"]),
+    )?;
+
+    let settings = tenex::app::Settings {
+        review_agent_program: tenex::app::AgentProgram::Custom,
+        review_custom_agent_command: codex_path.to_string_lossy().into_owned(),
+        ..Default::default()
+    };
+
+    let mut app = tenex::App::new(config, storage, settings, false);
+    app.set_cwd_project_root(Some(fixture.repo_path.clone()));
+    let handler = tenex::app::Actions::new();
+
+    app.data.spawn.child_count = 1;
+    app.data.spawn.spawning_under = None;
+    let spawn_result = handler.spawn_children(&mut app.data, Some("test-swarm"));
+    if spawn_result.is_err() {
+        return Ok(());
+    }
+
+    let root = app
+        .data
+        .storage
+        .iter()
+        .find(|agent| agent.is_root())
+        .ok_or("No root agent found")?;
+    let root_id = root.id;
+
+    app.data.spawn.spawning_under = Some(root_id);
+    app.data.spawn.child_count = 1;
+    app.data.review.base_branch = Some("stage".to_string());
+
+    let review_result = handler.spawn_review_agents(&mut app.data);
+
+    let capture = tenex::mux::OutputCapture::new();
+    let mut checked = 0usize;
+    for agent in app
+        .data
+        .storage
+        .iter()
+        .filter(|agent| agent.title.contains("Reviewer"))
+    {
+        let window_index = agent
+            .window_index
+            .ok_or("Missing window index for review agent")?;
+        let target = SessionManager::window_target(&agent.mux_session, window_index);
+        let output = {
+            let start = std::time::Instant::now();
+            let timeout = std::time::Duration::from_secs(10);
+            let poll_interval = std::time::Duration::from_millis(100);
+            let mut last_output = String::new();
+
+            loop {
+                match capture.capture_pane_with_history(&target, 200) {
+                    Ok(output) => {
+                        if output.contains("review started") {
+                            break output;
+                        }
+                        last_output = output;
+                    }
+                    Err(_) if start.elapsed() < timeout => {}
+                    Err(err) => return Err(err.into()),
+                }
+                if start.elapsed() >= timeout {
+                    break last_output;
+                }
+                std::thread::sleep(poll_interval);
+            }
+        };
+
+        assert!(
+            output.contains("'feature/stage'"),
+            "Expected mock Codex picker to select the first contains match, got: {output:?}"
+        );
+        checked = checked.saturating_add(1);
+    }
+
+    if review_result.is_err() {
+        return Ok(());
+    }
+
+    assert!(checked > 0, "Expected at least one Codex review agent");
+    let status = app.data.ui.status_message.as_deref().unwrap_or_default();
+    assert!(
+        status.contains("Codex review may be running against a different base than requested"),
+        "Expected user-visible mismatch status, got: {status:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg(not(unix))]
+fn test_spawn_review_agents_codex_warns_when_branch_picker_selects_colliding_name() {}
 
 #[test]
 fn test_review_prompt_contains_base_branch() {


### PR DESCRIPTION
Fixes #124.

The review swarm's chosen base branch was bracketed-pasted into Codex's /review branch picker, which ignores pasted text, so Codex reviews always ran against the default main/master. The branch is now typed as keys, and because Codex's picker filters by case-insensitive contains with no exact-match promotion, the flow verifies the review-start confirmation names the exact selected base (format string confirmed against Codex's own source) and surfaces a visible warning on mismatch instead of failing silently. The orphaned paste_keys helper this left behind is removed.

Validation
- cargo fmt, clippy (all targets, all features, -D warnings), and the full test suite pass on Linux.
- Cross-OS theoretical-max coverage gate passes at 100.00% for regions, functions, lines, and branches on linux, macos, and windows. No measured source surface changed (the fix lives in coverage-excluded swarm.rs), so committed receipts remain byte-valid.
- Targeted regression tests verified on macOS and Windows WSL2.

Tests
- Byte-level unit test pins that the base branch is sent unbracketed and the flow reports an exact base match.
- Integration mock now models the real picker (ignores pastes, contains-filter with preserved order); regressions cover the clean "stage" selection and the colliding "feature/stage" warning path.
- build_review_prompt regression for non-default branches.