### PR TITLE
Handle stale worktree targets on creation

### DIFF
--- a/src/app/handlers/agent_lifecycle.rs
+++ b/src/app/handlers/agent_lifecycle.rs
@@ -4,7 +4,7 @@
 use crate::agent::{Agent, AgentRuntime, ChildConfig};
 use crate::git::{self, WorktreeCreateOptions, WorktreeManager};
 use crate::mux::SessionManager;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -559,8 +559,13 @@ impl Actions {
 
         let worktree_mgr = WorktreeManager::new(&repo);
 
-        // Check if worktree/branch already exists - prompt user for action
-        if let Some(conflict_worktree_path) = worktree_mgr.worktree_path(&branch) {
+        let target_preparation = worktree_mgr.prepare_worktree_creation_target(
+            &worktree_path,
+            &branch,
+            &app_data.config.worktree_dir_for_repo_root(&repo_path),
+        )?;
+
+        if let Some(conflict_worktree_path) = target_preparation.registered_path() {
             debug!(branch, "Worktree already exists, prompting user");
 
             // Get current HEAD info for new worktree context
@@ -578,7 +583,7 @@ impl Actions {
                 title: title.to_string(),
                 prompt: prompt.map(String::from),
                 branch: branch.clone(),
-                worktree_path: conflict_worktree_path,
+                worktree_path: conflict_worktree_path.to_path_buf(),
                 repo_root: repo_path.clone(),
                 existing_branch,
                 existing_commit,
@@ -592,7 +597,11 @@ impl Actions {
             .into());
         }
 
+        let cleaned_stale_target = target_preparation.cleaned_stale_target();
         self.create_agent_internal(app_data, &repo_path, title, prompt, &branch, &worktree_path)?;
+        if cleaned_stale_target {
+            app_data.set_status(format!("Cleaned stale worktree and created agent: {title}"));
+        }
         Ok(AppMode::normal())
     }
 
@@ -635,6 +644,17 @@ impl Actions {
         let repo = git::open_repository(repo_path)?;
         let worktree_mgr = WorktreeManager::new(&repo);
         let runtime = crate::runtime::new_root_runtime(&app_data.settings);
+        let target_preparation = worktree_mgr.prepare_worktree_creation_target(
+            worktree_path,
+            branch,
+            &app_data.config.worktree_dir_for_repo_root(repo_path),
+        )?;
+        if let Some(registered_path) = target_preparation.registered_path() {
+            bail!(
+                "Cannot create worktree for branch '{branch}' because a registered worktree already exists at {}",
+                registered_path.display()
+            );
+        }
 
         let created = worktree_mgr.create_with_new_branch_with_options(
             worktree_path,
@@ -660,7 +680,11 @@ impl Actions {
         app_data.select_agent_by_id(agent_id);
 
         info!(title, %branch, "Agent created successfully");
-        app_data.set_status(format!("Created agent: {title}"));
+        if target_preparation.cleaned_stale_target() {
+            app_data.set_status(format!("Cleaned stale worktree and created agent: {title}"));
+        } else {
+            app_data.set_status(format!("Created agent: {title}"));
+        }
         Ok(())
     }
 
@@ -1122,11 +1146,16 @@ impl Actions {
         branch: &str,
         runtime: AgentRuntime,
     ) -> Result<std::path::PathBuf> {
-        if let Some(path) = worktree_mgr.worktree_path(branch) {
-            return Ok(path);
+        let worktree_path = config.worktree_path_for_repo_root(repo_root, branch);
+        let target_preparation = worktree_mgr.prepare_worktree_creation_target(
+            &worktree_path,
+            branch,
+            &config.worktree_dir_for_repo_root(repo_root),
+        )?;
+        if let Some(path) = target_preparation.registered_path() {
+            return Ok(path.to_path_buf());
         }
 
-        let worktree_path = config.worktree_path_for_repo_root(repo_root, branch);
         let created = worktree_mgr.create_with_options(
             &worktree_path,
             branch,
@@ -1988,7 +2017,7 @@ mod tests {
             .expect_err("expected recreate_worktree to error");
         assert!(
             err.to_string()
-                .contains("Failed to create parent directory")
+                .contains("Failed to inspect worktree target")
         );
     }
 
@@ -2227,7 +2256,7 @@ mod tests {
                 .expect_err("expected create_agent to error");
         assert!(
             err.to_string()
-                .contains("Failed to create parent directory")
+                .contains("Failed to inspect worktree target")
         );
     }
 
@@ -3307,7 +3336,101 @@ mod tests {
                 &worktree_path,
             )
             .expect_err("expected create_agent_internal to fail");
-        assert!(err.to_string().contains("worktree"));
+        let message = err.to_string();
+        assert!(message.contains(&worktree_path.display().to_string()));
+        assert!(message.contains("does not look like one of this repo's Tenex worktrees"));
+    }
+
+    #[test]
+    fn test_create_agent_internal_cleans_empty_stale_worktree_path() -> anyhow::Result<()> {
+        let _guard = crate::test_support::lock_mux_test_environment();
+        let socket = crate::test_support::unique_mux_socket_path("agent-life-stale-empty");
+        crate::mux::set_socket_override(&socket)?;
+
+        let handler = Actions::new();
+        let (mut app, _temp) = create_test_app();
+        let (_repo_dir, repo_root) = init_repo();
+        let worktree_dir = TempDir::new()?;
+
+        app.data.config.worktree_dir = worktree_dir.path().to_path_buf();
+        app.data.config.branch_prefix = "tenex-test/".to_string();
+
+        let branch = "tenex-test/stale-empty".to_string();
+        let worktree_path = app
+            .data
+            .config
+            .worktree_path_for_repo_root(&repo_root, &branch);
+        std::fs::create_dir_all(&worktree_path)?;
+
+        handler.create_agent_internal(
+            &mut app.data,
+            &repo_root,
+            "stale empty",
+            None,
+            &branch,
+            &worktree_path,
+        )?;
+
+        assert!(worktree_path.join(".git").is_file());
+        assert_eq!(
+            app.data.ui.status_message.as_deref(),
+            Some("Cleaned stale worktree and created agent: stale empty")
+        );
+
+        for agent in app.data.storage.iter() {
+            let _ = crate::mux::SessionManager::new().kill(&agent.mux_session);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_agent_internal_cleans_broken_checkout_worktree_path() -> anyhow::Result<()> {
+        let _guard = crate::test_support::lock_mux_test_environment();
+        let socket = crate::test_support::unique_mux_socket_path("agent-life-stale-broken");
+        crate::mux::set_socket_override(&socket)?;
+
+        let handler = Actions::new();
+        let (mut app, _temp) = create_test_app();
+        let (_repo_dir, repo_root) = init_repo();
+        let repo = git::open_repository(&repo_root)?;
+        let worktree_dir = TempDir::new()?;
+
+        app.data.config.worktree_dir = worktree_dir.path().to_path_buf();
+        app.data.config.branch_prefix = "tenex-test/".to_string();
+
+        let branch = "tenex-test/stale-broken".to_string();
+        let worktree_path = app
+            .data
+            .config
+            .worktree_path_for_repo_root(&repo_root, &branch);
+        let admin_dir = repo.path().join("worktrees").join(branch.replace('/', "-"));
+        std::fs::create_dir_all(&worktree_path)?;
+        std::fs::write(
+            worktree_path.join(".git"),
+            format!("gitdir: {}\n", admin_dir.display()),
+        )?;
+        std::fs::write(worktree_path.join("payload.txt"), "stale")?;
+
+        handler.create_agent_internal(
+            &mut app.data,
+            &repo_root,
+            "stale broken",
+            None,
+            &branch,
+            &worktree_path,
+        )?;
+
+        assert!(worktree_path.join(".git").is_file());
+        assert!(!worktree_path.join("payload.txt").exists());
+        assert_eq!(
+            app.data.ui.status_message.as_deref(),
+            Some("Cleaned stale worktree and created agent: stale broken")
+        );
+
+        for agent in app.data.storage.iter() {
+            let _ = crate::mux::SessionManager::new().kill(&agent.mux_session);
+        }
+        Ok(())
     }
 
     #[test]
@@ -3843,7 +3966,41 @@ mod tests {
             AgentRuntime::Host,
         )
         .expect_err("expected non-empty worktree path to error");
-        assert!(err.to_string().contains("worktree"));
+        let message = err.to_string();
+        assert!(message.contains(&worktree_path.display().to_string()));
+        assert!(message.contains("does not look like one of this repo's Tenex worktrees"));
+    }
+
+    #[test]
+    fn test_ensure_worktree_for_branch_cleans_empty_stale_target_path() -> anyhow::Result<()> {
+        let (_repo_dir, repo_root) = init_repo();
+        let worktree_dir = TempDir::new()?;
+
+        let config = Config {
+            worktree_dir: worktree_dir.path().to_path_buf(),
+            branch_prefix: "tenex-test/".to_string(),
+            ..Config::default()
+        };
+
+        let repo = git::open_repository(&repo_root)?;
+        let branch_mgr = git::BranchManager::new(&repo);
+        branch_mgr.create("feature")?;
+
+        let worktree_mgr = WorktreeManager::new(&repo);
+        let worktree_path = config.worktree_path_for_repo_root(&repo_root, "feature");
+        std::fs::create_dir_all(&worktree_path)?;
+
+        let created = Actions::ensure_worktree_for_branch(
+            &config,
+            &repo_root,
+            &worktree_mgr,
+            "feature",
+            AgentRuntime::Host,
+        )?;
+
+        assert_eq!(created.canonicalize()?, worktree_path.canonicalize()?);
+        assert!(worktree_path.join(".git").is_file());
+        Ok(())
     }
 
     #[test]

--- a/src/app/handlers/swarm.rs
+++ b/src/app/handlers/swarm.rs
@@ -28,6 +28,11 @@ pub struct SpawnConfig {
     pub parent_agent_id: uuid::Uuid,
 }
 
+struct NewRootSpawnConfig {
+    config: SpawnConfig,
+    cleaned_stale_worktree: bool,
+}
+
 #[derive(Clone, Copy)]
 struct ReviewChildAgentConfig<'a> {
     root_session: &'a str,
@@ -679,11 +684,11 @@ impl Actions {
             "Spawning child agents"
         );
 
-        let spawn_config = if let Some(pid) = parent_id {
-            Self::get_existing_parent_config(app_data, pid)?
+        let (spawn_config, cleaned_stale_worktree) = if let Some(pid) = parent_id {
+            (Self::get_existing_parent_config(app_data, pid)?, false)
         } else {
             match self.create_new_root_for_swarm(app_data, task, count)? {
-                Some(config) => config,
+                Some(new_root) => (new_root.config, new_root.cleaned_stale_worktree),
                 None => {
                     return Ok(ConfirmingMode {
                         action: ConfirmAction::WorktreeConflict,
@@ -702,7 +707,13 @@ impl Actions {
 
         app_data.storage.save()?;
         info!(count, parent_id = %spawn_config.parent_agent_id, "Child agents spawned successfully");
-        app_data.set_status(format!("Spawned {count} child agents"));
+        if cleaned_stale_worktree {
+            app_data.set_status(format!(
+                "Cleaned stale worktree and spawned {count} child agents"
+            ));
+        } else {
+            app_data.set_status(format!("Spawned {count} child agents"));
+        }
         Ok(AppMode::normal())
     }
 
@@ -733,7 +744,7 @@ impl Actions {
         app_data: &mut AppData,
         task: Option<&str>,
         count: usize,
-    ) -> Result<Option<SpawnConfig>> {
+    ) -> Result<Option<NewRootSpawnConfig>> {
         let root_title = Self::generate_root_title(task);
         let cwd_fallback = PathBuf::from(".");
         let repo_path = Self::resolve_swarm_repo_path(
@@ -742,29 +753,37 @@ impl Actions {
         );
         let Ok(repo) = git::open_repository(&repo_path) else {
             let config = self.create_plain_dir_root_for_swarm(app_data, root_title, repo_path)?;
-            return Ok(Some(config));
+            return Ok(Some(NewRootSpawnConfig {
+                config,
+                cleaned_stale_worktree: false,
+            }));
         };
         let branch = app_data.config.generate_branch_name(&root_title);
 
         let worktree_mgr = WorktreeManager::new(&repo);
 
-        if let Some(conflict_worktree_path) = worktree_mgr.worktree_path(&branch) {
+        let worktree_path = app_data
+            .config
+            .worktree_path_for_repo_root(&repo_path, &branch);
+        let target_preparation = worktree_mgr.prepare_worktree_creation_target(
+            &worktree_path,
+            &branch,
+            &app_data.config.worktree_dir_for_repo_root(&repo_path),
+        )?;
+
+        if let Some(conflict_worktree_path) = target_preparation.registered_path() {
             Self::setup_worktree_conflict(
                 app_data,
                 &worktree_mgr,
                 root_title,
                 task,
                 branch,
-                conflict_worktree_path,
+                conflict_worktree_path.to_path_buf(),
                 count,
                 repo_path,
             );
             return Ok(None);
         }
-
-        let worktree_path = app_data
-            .config
-            .worktree_path_for_repo_root(&repo_path, &branch);
 
         let runtime = crate::runtime::new_root_runtime(&app_data.settings);
         let worktree_options = Self::root_worktree_create_options(runtime);
@@ -785,13 +804,16 @@ impl Actions {
         let root_id = root_agent.id;
 
         app_data.storage.add(root_agent);
-        Ok(Some(SpawnConfig {
-            root_session,
-            worktree_path,
-            branch,
-            workspace_kind: WorkspaceKind::GitWorktree,
-            runtime,
-            parent_agent_id: root_id,
+        Ok(Some(NewRootSpawnConfig {
+            config: SpawnConfig {
+                root_session,
+                worktree_path,
+                branch,
+                workspace_kind: WorkspaceKind::GitWorktree,
+                runtime,
+                parent_agent_id: root_id,
+            },
+            cleaned_stale_worktree: target_preparation.cleaned_stale_target(),
         }))
     }
 
@@ -2647,7 +2669,7 @@ mod tests {
             .expect_err("expected worktree create to error");
         assert!(
             err.to_string()
-                .contains("Failed to create parent directory")
+                .contains("Failed to inspect worktree target")
         );
         assert!(app.data.storage.is_empty());
     }
@@ -2780,6 +2802,50 @@ mod tests {
         let expected_repo_root = canonicalize_or_self(&repo_path);
         assert_eq!(actual_repo_root, expected_repo_root);
         assert_eq!(conflict.swarm_child_count, Some(2));
+    }
+
+    #[test]
+    fn test_spawn_children_cleans_empty_stale_root_worktree_path() -> anyhow::Result<()> {
+        let _mux_guard = crate::test_support::lock_mux_test_environment();
+        let socket = crate::test_support::unique_mux_socket_path("swarm-stale-empty");
+        crate::mux::set_socket_override(&socket)?;
+
+        let (mut app, _temp) = create_test_app();
+        let (_repo_dir, repo_path) = init_git_repo();
+        let worktree_dir = tempfile::TempDir::new()?;
+
+        app.data.spawn.root_repo_path = Some(repo_path.clone());
+        app.data.config.worktree_dir = worktree_dir.path().to_path_buf();
+        app.data.spawn.spawning_under = None;
+        app.data.spawn.child_count = 1;
+
+        let task = "stale swarm";
+        let root_title = Actions::generate_root_title(Some(task));
+        let branch = app.data.config.generate_branch_name(&root_title);
+        let worktree_path = app
+            .data
+            .config
+            .worktree_path_for_repo_root(&repo_path, &branch);
+        std::fs::create_dir_all(&worktree_path)?;
+
+        let next = with_tracing_dispatch(|| {
+            let handler = Actions::new();
+            handler.spawn_children(&mut app.data, Some(task))
+        })?;
+        app.apply_mode(next);
+
+        assert_eq!(app.mode, AppMode::normal());
+        assert!(worktree_path.join(".git").is_file());
+        assert_eq!(app.data.storage.len(), 2);
+        assert_eq!(
+            app.data.ui.status_message.as_deref(),
+            Some("Cleaned stale worktree and spawned 1 child agents")
+        );
+
+        for agent in app.data.storage.iter() {
+            let _ = SessionManager::new().kill(&agent.mux_session);
+        }
+        Ok(())
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -13,6 +13,7 @@ pub use diff::{
 };
 pub use worktree::{
     CreateOptions as WorktreeCreateOptions, Info as WorktreeInfo, Manager as WorktreeManager,
+    TargetPreparation as WorktreeTargetPreparation,
 };
 
 use anyhow::{Context, Result};

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -165,6 +165,54 @@ fn is_empty_dir(path: &Path) -> Result<bool> {
     Ok(entries.next().is_none())
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TargetPreparationKind {
+    Registered(PathBuf),
+    Ready { cleaned_stale_target: bool },
+}
+
+/// Result of checking a worktree target before creation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetPreparation {
+    kind: TargetPreparationKind,
+}
+
+impl TargetPreparation {
+    const fn registered(path: PathBuf) -> Self {
+        Self {
+            kind: TargetPreparationKind::Registered(path),
+        }
+    }
+
+    const fn ready(cleaned_stale_target: bool) -> Self {
+        Self {
+            kind: TargetPreparationKind::Ready {
+                cleaned_stale_target,
+            },
+        }
+    }
+
+    /// Returns the registered worktree path when git already knows this branch's worktree.
+    #[must_use]
+    pub fn registered_path(&self) -> Option<&Path> {
+        match &self.kind {
+            TargetPreparationKind::Registered(path) => Some(path),
+            TargetPreparationKind::Ready { .. } => None,
+        }
+    }
+
+    /// Returns true when preparation removed a stale Tenex-owned target directory.
+    #[must_use]
+    pub const fn cleaned_stale_target(&self) -> bool {
+        match &self.kind {
+            TargetPreparationKind::Registered(_) => false,
+            TargetPreparationKind::Ready {
+                cleaned_stale_target,
+            } => *cleaned_stale_target,
+        }
+    }
+}
+
 fn normalize_ignored_rel_path(raw_path: &[u8]) -> Option<PathBuf> {
     use std::ffi::OsStr;
     use std::path::Component;
@@ -515,6 +563,193 @@ impl<'a> Manager<'a> {
         Self { repo }
     }
 
+    /// Prepare a worktree target path before creating or reusing it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the path already exists but is not a safe Tenex-owned
+    /// stale worktree target, or when stale cleanup fails.
+    pub fn prepare_worktree_creation_target(
+        &self,
+        path: &Path,
+        branch: &str,
+        worktree_root: &Path,
+    ) -> Result<TargetPreparation> {
+        if let Some(registered_path) = self.worktree_path(branch) {
+            return Ok(TargetPreparation::registered(registered_path));
+        }
+
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(TargetPreparation::ready(false));
+            }
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("Failed to inspect worktree target {}", path.display())
+                });
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            bail!(
+                "Cannot create Tenex worktree at {} because that path is a symlink; Tenex will not create a worktree at or traverse it",
+                path.display()
+            );
+        }
+        if metadata.is_file() {
+            bail!(
+                "Cannot create Tenex worktree at {} because that path is a file, not a directory Tenex can use",
+                path.display()
+            );
+        }
+        if !metadata.is_dir() {
+            bail!(
+                "Cannot create Tenex worktree at {} because that path is not a directory Tenex can use",
+                path.display()
+            );
+        }
+        if !Self::existing_path_is_inside_root(path, worktree_root) {
+            bail!(
+                "Cannot create Tenex worktree at {} because it is outside the configured Tenex worktree root {}; Tenex will not touch it automatically",
+                path.display(),
+                worktree_root.display()
+            );
+        }
+
+        let worktree_name = branch.replace('/', "-");
+        let stale_empty = is_empty_dir(path)?;
+        let stale_owned = if stale_empty {
+            false
+        } else {
+            self.target_dir_looks_like_stale_own_worktree(path, &worktree_name)?
+        };
+
+        if stale_empty || stale_owned {
+            remove_dir_all_with_retries(path).with_context(|| {
+                format!(
+                    "Failed to remove stale Tenex worktree target {}",
+                    path.display()
+                )
+            })?;
+            return Ok(TargetPreparation::ready(true));
+        }
+
+        bail!(
+            "Cannot create Tenex worktree at {} because that directory already exists and does not look like one of this repo's Tenex worktrees; Tenex will not delete or reuse it automatically",
+            path.display()
+        );
+    }
+
+    fn existing_path_is_inside_root(path: &Path, root: &Path) -> bool {
+        let Ok(path) = path.canonicalize() else {
+            return false;
+        };
+        let Ok(root) = root.canonicalize() else {
+            return false;
+        };
+
+        path != root && path.starts_with(root)
+    }
+
+    fn target_dir_looks_like_stale_own_worktree(
+        &self,
+        path: &Path,
+        worktree_name: &str,
+    ) -> Result<bool> {
+        let admin_dir = self.repo.path().join("worktrees").join(worktree_name);
+        Self::target_git_file_points_to_admin_dir(path, &admin_dir)
+    }
+
+    fn target_git_file_points_to_admin_dir(path: &Path, admin_dir: &Path) -> Result<bool> {
+        let git_file = path.join(".git");
+        if !git_file.exists() {
+            return Ok(false);
+        }
+
+        let metadata = fs::symlink_metadata(&git_file)
+            .with_context(|| format!("Failed to inspect {}", git_file.display()))?;
+        if !metadata.is_file() {
+            return Ok(false);
+        }
+
+        let Some(gitdir) = Self::read_gitdir_pointer(&git_file, path)? else {
+            return Ok(false);
+        };
+
+        Ok(Self::paths_match(&gitdir, admin_dir))
+    }
+
+    fn read_gitdir_pointer(path: &Path, relative_base: &Path) -> Result<Option<PathBuf>> {
+        Self::read_resolved_gitdir(path, relative_base, |raw| {
+            raw.trim()
+                .strip_prefix("gitdir:")
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+        })
+    }
+
+    fn read_gitdir_path_file(path: &Path, relative_base: &Path) -> Result<Option<PathBuf>> {
+        Self::read_resolved_gitdir(path, relative_base, |raw| {
+            let gitdir = raw.trim();
+            if gitdir.is_empty() {
+                None
+            } else {
+                Some(gitdir.to_string())
+            }
+        })
+    }
+
+    fn read_resolved_gitdir(
+        path: &Path,
+        relative_base: &Path,
+        parse: impl FnOnce(&str) -> Option<String>,
+    ) -> Result<Option<PathBuf>> {
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        Ok(parse(&raw).map(|gitdir| Self::resolve_gitdir_path(&gitdir, relative_base)))
+    }
+
+    fn resolve_gitdir_path(gitdir: &str, relative_base: &Path) -> PathBuf {
+        let candidate = PathBuf::from(gitdir);
+        if candidate.is_absolute() {
+            candidate
+        } else {
+            relative_base.join(candidate)
+        }
+    }
+
+    fn paths_match(left: &Path, right: &Path) -> bool {
+        if let (Ok(left), Ok(right)) = (left.canonicalize(), right.canonicalize()) {
+            return left == right;
+        }
+
+        Self::normalize_absolute_path(left) == Self::normalize_absolute_path(right)
+    }
+
+    fn normalize_absolute_path(path: &Path) -> PathBuf {
+        Self::normalize_path_components(path)
+    }
+
+    fn normalize_path_components(path: &Path) -> PathBuf {
+        use std::path::Component;
+
+        let mut normalized = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    normalized.pop();
+                }
+                Component::Normal(part) => normalized.push(part),
+                component @ (Component::Prefix(_) | Component::RootDir) => {
+                    normalized.push(component.as_os_str());
+                }
+            }
+        }
+        normalized
+    }
+
     /// Create a new worktree for a branch
     ///
     /// # Errors
@@ -780,27 +1015,18 @@ impl<'a> Manager<'a> {
         } else {
             let gitdir_path = admin_dir.join("gitdir");
             if gitdir_path.exists() {
-                let raw_gitdir = fs::read_to_string(&gitdir_path)
-                    .context(format!("Failed to read {}", gitdir_path.display()))?;
-                let gitdir = raw_gitdir.trim();
-                if gitdir.is_empty() {
-                    Some(RemoveReason::EmptyGitdir)
-                } else {
-                    let candidate = PathBuf::from(gitdir);
-                    let resolved = if candidate.is_absolute() {
-                        candidate
-                    } else {
-                        admin_dir.join(candidate)
-                    };
-
-                    if resolved.exists() {
-                        None
-                    } else {
-                        Some(RemoveReason::Stale {
-                            resolved_gitdir: resolved,
-                        })
-                    }
-                }
+                Self::read_gitdir_path_file(&gitdir_path, &admin_dir)?.map_or(
+                    Some(RemoveReason::EmptyGitdir),
+                    |resolved| {
+                        if resolved.exists() {
+                            None
+                        } else {
+                            Some(RemoveReason::Stale {
+                                resolved_gitdir: resolved,
+                            })
+                        }
+                    },
+                )
             } else {
                 Some(RemoveReason::MissingGitdir)
             }
@@ -1344,6 +1570,469 @@ mod tests {
 
         remove_dir_all_with_retries(&file_path).unwrap();
         assert!(!file_path.exists());
+    }
+
+    fn admin_dir_for_branch(repo: &Repository, branch: &str) -> PathBuf {
+        repo.path().join("worktrees").join(branch.replace('/', "-"))
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_reports_missing_path_ready() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("missing");
+
+        let branch = "feature/missing";
+        let root = worktree_root.path();
+        let preparation = manager.prepare_worktree_creation_target(&path, branch, root)?;
+
+        assert!(preparation.registered_path().is_none());
+        assert!(!preparation.cleaned_stale_target());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_reports_registered_worktree() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("registered");
+        let branch = "feature/registered";
+        manager.create_with_new_branch(&path, branch)?;
+
+        let preparation =
+            manager.prepare_worktree_creation_target(&path, branch, worktree_root.path())?;
+        let registered_path = preparation
+            .registered_path()
+            .ok_or_else(|| anyhow::anyhow!("missing registered path"))?;
+
+        assert_eq!(registered_path.canonicalize()?, path.canonicalize()?);
+        assert!(!preparation.cleaned_stale_target());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_removes_empty_stale_dir() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("empty-stale");
+        let branch = "feature/empty-stale";
+        fs::create_dir_all(&path)?;
+
+        let preparation =
+            manager.prepare_worktree_creation_target(&path, branch, worktree_root.path())?;
+
+        assert!(preparation.registered_path().is_none());
+        assert!(preparation.cleaned_stale_target());
+        assert!(!path.exists());
+        manager.create_with_new_branch(&path, branch)?;
+        assert!(path.join(".git").is_file());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_removes_target_git_file_match() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("git-file-stale");
+        let branch = "feature/git-file-stale";
+        let admin_dir = admin_dir_for_branch(&repo, branch);
+        fs::create_dir_all(&admin_dir)?;
+        fs::create_dir_all(&path)?;
+        let gitdir = format!("gitdir: {}\n", admin_dir.display());
+        fs::write(path.join(".git"), gitdir)?;
+        fs::write(path.join("payload.txt"), "stale")?;
+
+        let preparation =
+            manager.prepare_worktree_creation_target(&path, branch, worktree_root.path())?;
+
+        assert!(preparation.cleaned_stale_target());
+        assert!(!path.exists());
+        manager.create_with_new_branch(&path, branch)?;
+        assert!(path.join(".git").is_file());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_removes_missing_admin_git_file_match() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("missing-admin-stale");
+        let branch = "feature/missing-admin-stale";
+        let admin_dir = admin_dir_for_branch(&repo, branch);
+        fs::create_dir_all(&path)?;
+        let gitdir = format!("gitdir: {}\n", admin_dir.display());
+        fs::write(path.join(".git"), gitdir)?;
+        fs::write(path.join("payload.txt"), "stale")?;
+
+        let preparation =
+            manager.prepare_worktree_creation_target(&path, branch, worktree_root.path())?;
+
+        assert!(preparation.cleaned_stale_target());
+        assert!(!path.exists());
+        manager.create_with_new_branch(&path, branch)?;
+        assert!(path.join(".git").is_file());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_non_empty_admin_gitdir_file_match_without_target_git_file()
+    -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("admin-gitdir-file-stale");
+        let branch = "feature/admin-gitdir-file-stale";
+        let admin_dir = admin_dir_for_branch(&repo, branch);
+        fs::create_dir_all(&admin_dir)?;
+        fs::create_dir_all(&path)?;
+        let gitdir = path.join(".git").display().to_string();
+        fs::write(admin_dir.join("gitdir"), gitdir)?;
+        fs::write(path.join("payload.txt"), "stale")?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, branch, worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected admin-only foreign path error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("does not look like one of this repo's Tenex worktrees"));
+        assert!(path.join("payload.txt").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_removes_empty_admin_gitdir_target_match() -> Result<()>
+    {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("admin-gitdir-target-stale");
+        let branch = "feature/admin-gitdir-target-stale";
+        let admin_dir = admin_dir_for_branch(&repo, branch);
+        fs::create_dir_all(&admin_dir)?;
+        fs::create_dir_all(&path)?;
+        fs::write(admin_dir.join("gitdir"), path.display().to_string())?;
+
+        let preparation =
+            manager.prepare_worktree_creation_target(&path, branch, worktree_root.path())?;
+
+        assert!(preparation.cleaned_stale_target());
+        assert!(!path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_removes_relative_target_git_file_match() -> Result<()>
+    {
+        let (repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = repo_dir.path().join("tenex-worktrees");
+        let path = worktree_root.join("relative-gitdir-stale");
+        let branch = "feature/relative-gitdir-stale";
+        let worktree_name = branch.replace('/', "-");
+        let admin_dir = admin_dir_for_branch(&repo, branch);
+        fs::create_dir_all(&admin_dir)?;
+        fs::create_dir_all(&path)?;
+        let gitdir = format!("gitdir: ../../.git/worktrees/{worktree_name}\n");
+        fs::write(path.join(".git"), gitdir)?;
+        fs::write(path.join("payload.txt"), "stale")?;
+
+        let preparation =
+            manager.prepare_worktree_creation_target(&path, branch, &worktree_root)?;
+
+        assert!(preparation.cleaned_stale_target());
+        assert!(!path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_foreign_non_empty_dir() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("foreign");
+        fs::create_dir_all(&path)?;
+        fs::write(path.join("payload.txt"), "foreign")?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, "feature/foreign", worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected foreign path error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("does not look like one of this repo's Tenex worktrees"));
+        assert!(path.join("payload.txt").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_file_path() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("file-target");
+        fs::write(&path, "not a directory")?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, "feature/file-target", worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected file path error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("is a file, not a directory"));
+        assert!(path.is_file());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_dangling_symlink_path() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("dangling-symlink-target");
+        symlink(worktree_root.path().join("missing-destination"), &path)?;
+
+        let err = manager
+            .prepare_worktree_creation_target(
+                &path,
+                "feature/dangling-symlink",
+                worktree_root.path(),
+            )
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected symlink path error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("is a symlink"));
+        assert!(fs::symlink_metadata(&path)?.file_type().is_symlink());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_outside_symlink_path() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let outside = TempDir::new()?;
+        let path = worktree_root.path().join("outside-symlink-target");
+        symlink(outside.path(), &path)?;
+
+        let err = manager
+            .prepare_worktree_creation_target(
+                &path,
+                "feature/outside-symlink",
+                worktree_root.path(),
+            )
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected symlink path error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("is a symlink"));
+        assert!(outside.path().exists());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_inside_symlink_path() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let destination = worktree_root.path().join("inside-destination");
+        let path = worktree_root.path().join("inside-symlink-target");
+        fs::create_dir_all(&destination)?;
+        symlink(&destination, &path)?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, "feature/inside-symlink", worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected symlink path error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("is a symlink"));
+        assert!(destination.exists());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_socket_path() -> Result<()> {
+        use std::os::unix::net::UnixListener;
+
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("socket-target");
+        let listener = UnixListener::bind(&path)?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, "feature/socket", worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected socket path error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("is not a directory Tenex can use"));
+        drop(listener);
+        fs::remove_file(&path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_outside_worktree_root() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let outside = TempDir::new()?;
+        let path = outside.path().join("stale");
+        fs::create_dir_all(&path)?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, "feature/outside", worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected outside root error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains(&path.display().to_string()));
+        assert!(message.contains("outside the configured Tenex worktree root"));
+        assert!(path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_existing_path_is_inside_root_rejects_uncanonicalizable_inputs() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let existing_path = temp_dir.path().join("path");
+        let missing_path = temp_dir.path().join("missing-path");
+        let missing_root = temp_dir.path().join("missing-root");
+        fs::create_dir_all(&existing_path)?;
+
+        assert!(!Manager::existing_path_is_inside_root(
+            &missing_path,
+            temp_dir.path()
+        ));
+        assert!(!Manager::existing_path_is_inside_root(
+            &existing_path,
+            &missing_root
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_git_dir_marker_as_foreign() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("git-dir-marker");
+        fs::create_dir_all(path.join(".git"))?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, "feature/git-dir-marker", worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected git dir marker error"))?;
+
+        assert!(err.to_string().contains("does not look like"));
+        assert!(path.join(".git").is_dir());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_invalid_git_file_marker() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("invalid-git-file");
+        fs::create_dir_all(&path)?;
+        fs::write(path.join(".git"), "not a gitdir pointer")?;
+
+        let err = manager
+            .prepare_worktree_creation_target(
+                &path,
+                "feature/invalid-git-file",
+                worktree_root.path(),
+            )
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected invalid git file error"))?;
+
+        assert!(err.to_string().contains("does not look like"));
+        assert!(path.join(".git").is_file());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_worktree_creation_target_rejects_empty_admin_gitdir_file() -> Result<()> {
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("empty-admin-gitdir");
+        let branch = "feature/empty-admin-gitdir";
+        let admin_dir = admin_dir_for_branch(&repo, branch);
+        fs::create_dir_all(&admin_dir)?;
+        fs::write(admin_dir.join("gitdir"), "\n")?;
+        fs::create_dir_all(&path)?;
+        fs::write(path.join("payload.txt"), "foreign")?;
+
+        let err = manager
+            .prepare_worktree_creation_target(&path, branch, worktree_root.path())
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected empty admin gitdir error"))?;
+
+        assert!(err.to_string().contains("does not look like"));
+        assert!(path.join("payload.txt").exists());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_worktree_creation_target_reports_stale_removal_errors() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_repo_dir, repo) = init_test_repo_with_commit();
+        let manager = Manager::new(&repo);
+        let worktree_root = TempDir::new()?;
+        let path = worktree_root.path().join("unremovable-empty");
+        fs::create_dir_all(&path)?;
+        fs::set_permissions(worktree_root.path(), fs::Permissions::from_mode(0o500))?;
+
+        let result = manager.prepare_worktree_creation_target(
+            &path,
+            "feature/unremovable",
+            worktree_root.path(),
+        );
+        fs::set_permissions(worktree_root.path(), fs::Permissions::from_mode(0o700))?;
+        let err = result
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected stale removal error"))?;
+        let message = err.to_string();
+
+        assert!(message.contains("Failed to remove stale Tenex worktree target"));
+        assert!(message.contains(&path.display().to_string()));
+        assert!(path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_path_components_covers_dot_and_parent_segments() {
+        let normalized = Manager::normalize_path_components(Path::new("./tmp/../worktree"));
+        assert_eq!(normalized, PathBuf::from("worktree"));
     }
 
     #[test]

--- a/tests/integration/worktree_conflict.rs
+++ b/tests/integration/worktree_conflict.rs
@@ -141,6 +141,55 @@ fn test_worktree_conflict_reconnect_single_agent() -> Result<(), Box<dyn std::er
     Ok(())
 }
 
+/// Test that an unregistered stale directory is cleaned and recreated for a single agent
+#[test]
+fn test_stale_empty_worktree_path_creates_single_agent() -> anyhow::Result<()> {
+    if skip_if_no_mux() {
+        return Ok(());
+    }
+
+    let fixture =
+        TestFixture::new("wt_stale_empty_single").map_err(|err| anyhow::anyhow!("{err}"))?;
+
+    let config = fixture.config();
+    let storage = fixture.storage();
+    let mut app = App::new(config, storage, tenex::app::Settings::default(), false);
+    app.set_cwd_project_root(Some(fixture.repo_path.clone()));
+    let handler = Actions::new();
+
+    let title = "stale-empty-agent";
+    let branch_name = app.data.config.generate_branch_name(title);
+    let worktree_path = app
+        .data
+        .config
+        .worktree_path_for_repo_root(&fixture.repo_path, &branch_name);
+    fs::create_dir_all(&worktree_path)?;
+
+    let next = handler.create_agent(&mut app.data, title, Some("test prompt"))?;
+    app.apply_mode(next);
+
+    assert_eq!(app.mode, tenex::AppMode::normal());
+    assert!(app.data.spawn.worktree_conflict.is_none());
+    assert!(worktree_path.join(".git").is_file());
+    assert_eq!(
+        app.data.ui.status_message.as_deref(),
+        Some("Cleaned stale worktree and created agent: stale-empty-agent")
+    );
+
+    let agent = app
+        .data
+        .storage
+        .iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("expected created agent"))?;
+    assert_eq!(agent.title, title);
+
+    fixture.cleanup_sessions();
+    fixture.cleanup_branches();
+
+    Ok(())
+}
+
 /// Test recreating worktree (delete and create fresh)
 #[test]
 #[expect(clippy::expect_used, reason = "test assertions")]


### PR DESCRIPTION
Fixes #129.

Interrupted worktree creation could leave a stale directory at the target path; every retry with that label then failed with a raw libgit2 Exists error in a generic modal. Creation now runs a boundary classifier over (branch, admin dir, target path):

- Registered worktrees route to the existing reconnect modal, unchanged.
- Stale empty directories inside the Tenex worktree root are cleaned and recreated, with a status noting the cleanup.
- Non-empty directories are cleaned only with reciprocal proof of ownership: the target's own .git file must resolve back to this repo's matching worktree admin dir. Admin-side metadata alone is never sufficient (review finding: a stale admin pointer plus a user-recreated directory must not be deletable).
- Symlinks at the target are refused unconditionally, checked via symlink_metadata before any other classification (review finding: exists() follows links, letting dangling symlinks bypass classification).
- Files, sockets, foreign non-empty directories, and anything outside the canonical worktree root are refused with errors naming the path and reason.

Ambiguous metadata refuses rather than cleans. Deletion requires: real directory, not a symlink, canonically inside the configured worktree root, and (if non-empty) reciprocal ownership proof.

Validation
- Reproduction proven failing on clean baselines and passing post-fix on macOS and Windows WSL2; 19 classifier unit tests plus lifecycle/swarm/integration regressions.
- fmt, clippy (all targets, all features, -D warnings), full suite, and the cross-OS theoretical-max gate green at 100.00% on linux, macos, and windows; receipts regenerated from this head per platform.
- Review process: adversarial review surfaced the reciprocal-proof and symlink findings (both fixed with regression tests); concept-density review drove the SpawnConfig narrowing and shared gitdir-resolution helper.