### PR TITLE
Make CI failure-path tests deterministic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,23 +117,13 @@ repos:
 
       - id: cargo-fmt
         name: cargo fmt --check
-        entry: cargo fmt --all -- --check
+        entry: python3 scripts/precommit/run_cargo_hook.py fmt
         language: system
         pass_filenames: false
 
       - id: cargo-clippy
         name: cargo clippy (all targets, all features, deny warnings)
-        entry: bash -c
-        args:
-          - |
-              set -euo pipefail
-              if [ -z "${RUSTC_ICE:-}" ]; then
-                export RUSTC_ICE="${XDG_CACHE_HOME:-$HOME/.cache}/tenex/rustc-ice"
-              fi
-              if [ "${RUSTC_ICE}" != "0" ]; then
-                mkdir -p "$RUSTC_ICE"
-              fi
-              cargo clippy --all-targets --all-features -- -D warnings
+        entry: python3 scripts/precommit/run_cargo_hook.py clippy
         language: system
         pass_filenames: false
 
@@ -218,7 +208,7 @@ repos:
               sha_path="${receipt_dir}/llvm-cov-report.sha256"
 
               mkdir -p "$receipt_dir"
-              cargo llvm-cov report --profile coverage --ignore-filename-regex 'crates/vt100-ctt/' > "$report_path"
+              python3 scripts/precommit/run_cargo_hook.py report > "$report_path"
 
               python_bin="python3"
               if ! command -v "$python_bin" >/dev/null 2>&1; then

--- a/scripts/precommit/pre_push_theoretical_max_gate.py
+++ b/scripts/precommit/pre_push_theoretical_max_gate.py
@@ -227,9 +227,6 @@ def export_instrumented_summary(
     out_gz = out_dir / "llvm-cov-instrumented.summary.json.gz"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    if not run_cargo_hook.verify_llvm_cov_version(root):
-        raise RuntimeError("cargo-llvm-cov version mismatch")
-
     # Keep the instrumented summary in sync with the later coverage run.
     #
     # `run_cargo_hook.py coverage` wipes `target/llvm-cov-target` before collecting coverage, but
@@ -240,7 +237,9 @@ def export_instrumented_summary(
 
     state_dir = Path(tempfile.mkdtemp(prefix="tenex-pre-push-"))
     mux_socket = str(state_dir / "mux.sock")
-    env = os.environ.copy()
+    env = run_cargo_hook.sanitized_subprocess_environment(root=root)
+    if not run_cargo_hook.verify_llvm_cov_version(root, env=env):
+        raise RuntimeError("cargo-llvm-cov version mismatch")
     env["TENEX_STATE_PATH"] = str(state_dir / "state.json")
     env["TENEX_MUX_SOCKET"] = mux_socket
     run_cargo_hook.configure_rustc_ice(env)
@@ -300,7 +299,7 @@ def export_coverage_summary(*, root: Path, out_dir: Path) -> Path:
     out_gz = out_dir / "llvm-cov-report.summary.json.gz"
     out_dir.mkdir(parents=True, exist_ok=True)
     run_cargo_hook = load_run_cargo_hook(root)
-    env = os.environ.copy()
+    env = run_cargo_hook.sanitized_subprocess_environment(root=root)
     run_cargo_hook.configure_rustc_ice(env)
 
     result = subprocess.run(

--- a/scripts/precommit/run_cargo_hook.py
+++ b/scripts/precommit/run_cargo_hook.py
@@ -20,6 +20,33 @@ def repo_root() -> Path:
     return Path(output.strip())
 
 
+def clear_local_git_environment(env: dict[str, str], *, root: Path) -> None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--local-env-vars"],
+        cwd=root,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(detail or "git rev-parse --local-env-vars failed")
+
+    for name in result.stdout.splitlines():
+        if name:
+            env.pop(name, None)
+
+
+def sanitized_subprocess_environment(
+    *, root: Path, source_env: dict[str, str] | None = None
+) -> dict[str, str]:
+    env = os.environ.copy() if source_env is None else source_env.copy()
+    clear_local_git_environment(env, root=root)
+    return env
+
+
 def muxd_pids_from_proc(proc_dir: Path, socket: str, state_path: Path) -> set[int]:
     wanted_socket = f"TENEX_MUX_SOCKET={socket}"
     wanted_state_path = f"TENEX_STATE_PATH={state_path}"
@@ -145,13 +172,14 @@ def cleanup_hook_muxd(state_dir: Path, socket: str) -> None:
             continue
 
 
-def verify_llvm_cov_version(root: Path) -> bool:
+def verify_llvm_cov_version(root: Path, *, env: dict[str, str]) -> bool:
     required_version = (root / ".cargo-llvm-cov-version").read_text(encoding="utf-8").strip()
     result = subprocess.run(
         ["cargo", "llvm-cov", "--version"],
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
     installed_version = ""
     if result.returncode == 0:
@@ -181,6 +209,20 @@ def build_command(mode: str, *, root: Path) -> list[str]:
         if build_jobs.isdigit():
             job_args = ["--jobs", build_jobs]
 
+    if mode == "fmt":
+        return ["cargo", "fmt", "--all", "--", "--check"]
+
+    if mode == "clippy":
+        return [
+            "cargo",
+            "clippy",
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ]
+
     if mode == "test":
         return [
             "cargo",
@@ -188,6 +230,17 @@ def build_command(mode: str, *, root: Path) -> list[str]:
             *job_args,
             "--all-targets",
             "--all-features",
+        ]
+
+    if mode == "report":
+        return [
+            "cargo",
+            "llvm-cov",
+            "report",
+            "--profile",
+            "coverage",
+            "--ignore-filename-regex",
+            "crates/vt100-ctt/",
         ]
 
     command = [
@@ -244,18 +297,24 @@ def hook_tmp_root(env: dict[str, str]) -> str | None:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("mode", choices=("test", "coverage"))
+    parser.add_argument("mode", choices=("fmt", "clippy", "test", "coverage", "report"))
     args = parser.parse_args()
 
     root = repo_root()
+    env = sanitized_subprocess_environment(root=root)
 
-    if args.mode == "coverage" and not verify_llvm_cov_version(root):
+    if args.mode in ("coverage", "report") and not verify_llvm_cov_version(root, env=env):
         return 1
+
+    configure_rustc_ice(env)
+    command = build_command(args.mode, root=root)
+    if args.mode not in ("test", "coverage"):
+        result = subprocess.run(command, cwd=root, env=env, check=False)
+        return result.returncode
 
     if args.mode == "coverage":
         shutil.rmtree(root / "target" / "llvm-cov-target", ignore_errors=True)
 
-    env = os.environ.copy()
     tmp_root = hook_tmp_root(env)
     if tmp_root:
         env["TMPDIR"] = tmp_root
@@ -266,11 +325,9 @@ def main() -> int:
     mux_socket = str(state_dir / "mux.sock")
     env["TENEX_STATE_PATH"] = str(state_dir / "state.json")
     env["TENEX_MUX_SOCKET"] = mux_socket
-    configure_rustc_ice(env)
 
     cleanup_hook_muxd(state_dir, mux_socket)
     try:
-        command = build_command(args.mode, root=root)
         result = subprocess.run(
             command,
             cwd=root,

--- a/scripts/precommit/test_run_cargo_hook.py
+++ b/scripts/precommit/test_run_cargo_hook.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 def load_module():
@@ -21,6 +22,114 @@ run_cargo_hook = load_module()
 
 
 class RunCargoHookTests(unittest.TestCase):
+    def test_sanitized_subprocess_environment_preserves_outer_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            outer = Path(tmp) / "hook-repo"
+            fixture = Path(tmp) / "fixture-repo"
+            bootstrap_env = run_cargo_hook.sanitized_subprocess_environment(
+                root=run_cargo_hook.repo_root()
+            )
+
+            def git(repo: Path, *args: str, env: dict[str, str]) -> str:
+                result = run_cargo_hook.subprocess.run(
+                    ["git", "-C", str(repo), *args],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
+                return result.stdout.strip()
+
+            outer.mkdir()
+            git(outer, "init", "-q", env=bootstrap_env)
+            git(outer, "config", "user.name", "Tenex Test", env=bootstrap_env)
+            git(
+                outer,
+                "config",
+                "user.email",
+                "tenex-test@example.invalid",
+                env=bootstrap_env,
+            )
+            git(outer, "config", "commit.gpgsign", "false", env=bootstrap_env)
+            (outer / "README.md").write_text("base\n", encoding="utf-8")
+            git(outer, "add", "README.md", env=bootstrap_env)
+            git(outer, "commit", "-q", "--no-verify", "-m", "base", env=bootstrap_env)
+            (outer / "pending.txt").write_text("pending\n", encoding="utf-8")
+            git(outer, "add", "pending.txt", env=bootstrap_env)
+
+            head_before = git(outer, "rev-parse", "HEAD", env=bootstrap_env)
+            tree_before = git(outer, "write-tree", env=bootstrap_env)
+            gitdir_before = git(outer, "rev-parse", "--absolute-git-dir", env=bootstrap_env)
+            index_path = outer / ".git" / "index"
+            index_before = index_path.read_bytes()
+
+            contaminated_env = bootstrap_env.copy()
+            contaminated_env["GIT_DIR"] = str(outer / ".git")
+            contaminated_env["GIT_WORK_TREE"] = str(outer)
+            contaminated_env["GIT_INDEX_FILE"] = str(index_path)
+            fixture_env = run_cargo_hook.sanitized_subprocess_environment(
+                root=outer,
+                source_env=contaminated_env,
+            )
+
+            fixture.mkdir()
+            git(fixture, "init", "-q", env=fixture_env)
+            git(fixture, "config", "user.name", "Tenex Test", env=fixture_env)
+            git(
+                fixture,
+                "config",
+                "user.email",
+                "tenex-test@example.invalid",
+                env=fixture_env,
+            )
+            git(fixture, "config", "commit.gpgsign", "false", env=fixture_env)
+            (fixture / "README.md").write_text("fixture\n", encoding="utf-8")
+            git(fixture, "add", "README.md", env=fixture_env)
+            git(fixture, "commit", "-q", "--no-verify", "-m", "fixture", env=fixture_env)
+
+            self.assertTrue(git(fixture, "rev-parse", "HEAD", env=fixture_env))
+            self.assertEqual(git(outer, "rev-parse", "HEAD", env=bootstrap_env), head_before)
+            self.assertEqual(git(outer, "write-tree", env=bootstrap_env), tree_before)
+            self.assertEqual(
+                git(outer, "rev-parse", "--absolute-git-dir", env=bootstrap_env),
+                gitdir_before,
+            )
+            self.assertEqual(index_path.read_bytes(), index_before)
+
+    def test_clear_local_git_environment_removes_only_git_local_variables(self) -> None:
+        env = {
+            "GIT_DIR": "/repo/.git",
+            "GIT_INDEX_FILE": "/repo/.git/index",
+            "GIT_PAGER": "cat",
+            "PATH": "/usr/bin",
+        }
+        completed = run_cargo_hook.subprocess.CompletedProcess(
+            args=["git", "rev-parse", "--local-env-vars"],
+            returncode=0,
+            stdout="GIT_DIR\nGIT_INDEX_FILE\n",
+            stderr="",
+        )
+
+        with mock.patch.object(run_cargo_hook.subprocess, "run", return_value=completed):
+            run_cargo_hook.clear_local_git_environment(env, root=Path("/repo"))
+
+        self.assertEqual(env, {"GIT_PAGER": "cat", "PATH": "/usr/bin"})
+
+    def test_clear_local_git_environment_fails_closed(self) -> None:
+        env = {"GIT_DIR": "/repo/.git"}
+        completed = run_cargo_hook.subprocess.CompletedProcess(
+            args=["git", "rev-parse", "--local-env-vars"],
+            returncode=1,
+            stdout="",
+            stderr="cannot inspect git environment",
+        )
+
+        with mock.patch.object(run_cargo_hook.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(RuntimeError, "cannot inspect git environment"):
+                run_cargo_hook.clear_local_git_environment(env, root=Path("/repo"))
+
+        self.assertEqual(env, {"GIT_DIR": "/repo/.git"})
+
     def test_muxd_pids_from_proc_matches_exact_socket(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             proc_root = Path(tmp)

--- a/src/agent/storage.rs
+++ b/src/agent/storage.rs
@@ -149,7 +149,12 @@ fn set_temp_permissions(path: &Path, existing_permissions: Option<fs::Permission
     Ok(())
 }
 
-fn replace_state_file(path: &Path, tmp_path: &Path) -> Result<()> {
+fn commit_temp_state_file(
+    path: &Path,
+    tmp_path: &Path,
+    existing_permissions: Option<fs::Permissions>,
+) -> Result<()> {
+    set_temp_permissions(tmp_path, existing_permissions)?;
     fs::rename(tmp_path, path).with_context(|| {
         format!(
             "Failed to replace state file {} with {}",
@@ -161,6 +166,14 @@ fn replace_state_file(path: &Path, tmp_path: &Path) -> Result<()> {
 }
 
 fn write_state_atomically(path: &Path, contents: &str) -> Result<()> {
+    write_state_atomically_with_commit(path, contents, commit_temp_state_file)
+}
+
+fn write_state_atomically_with_commit(
+    path: &Path,
+    contents: &str,
+    commit: fn(&Path, &Path, Option<fs::Permissions>) -> Result<()>,
+) -> Result<()> {
     let existing_permissions = fs::metadata(path)
         .ok()
         .map(|metadata| metadata.permissions());
@@ -168,8 +181,7 @@ fn write_state_atomically(path: &Path, contents: &str) -> Result<()> {
 
     let write_result = (|| -> Result<()> {
         write_temp_state_file(&tmp_path, contents)?;
-        set_temp_permissions(&tmp_path, existing_permissions)?;
-        replace_state_file(path, &tmp_path)?;
+        commit(path, &tmp_path, existing_permissions)?;
         Ok(())
     })();
 
@@ -2267,50 +2279,57 @@ mod tests {
         }
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
-    fn test_write_state_atomically_returns_error_when_temp_file_disappears_before_permissions_set()
-    {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicBool, Ordering};
+    fn test_write_state_atomically_cleans_up_after_missing_temp_commit_failure() {
+        fn remove_temp_before_commit(
+            path: &Path,
+            tmp_path: &Path,
+            existing_permissions: Option<fs::Permissions>,
+        ) -> Result<()> {
+            assert_eq!(path.parent(), tmp_path.parent());
+            assert!(existing_permissions.is_some());
+            assert_eq!(
+                std::fs::read_to_string(tmp_path).expect("read written temp state"),
+                "replacement state"
+            );
+
+            std::fs::remove_file(tmp_path).expect("remove temp state before commit");
+            let err = commit_temp_state_file(path, tmp_path, existing_permissions)
+                .expect_err("missing temp state should fail during commit");
+
+            std::fs::write(tmp_path, "cleanup sentinel")
+                .expect("recreate temp state to prove outer cleanup");
+            Err(err)
+        }
 
         let temp_dir = TempDir::new().expect("temp dir");
         let state_path = temp_dir.path().join("state.json");
+        std::fs::write(&state_path, "previous state").expect("write existing state");
 
-        let removed_flag = Arc::new(AtomicBool::new(false));
-        let removed_flag_for_thread = Arc::clone(&removed_flag);
-        let watch_dir = temp_dir.path().to_path_buf();
+        let err = write_state_atomically_with_commit(
+            &state_path,
+            "replacement state",
+            remove_temp_before_commit,
+        )
+        .expect_err("missing temp state should fail before replacement");
 
-        std::fs::write(temp_dir.path().join("keep.txt"), "keep").expect("write keep file");
-        let prefix = format!(".state.json.tmp-{}-", std::process::id());
-        let watcher = std::thread::spawn(move || {
-            for _ in 0..20_000 {
-                let entries = std::fs::read_dir(&watch_dir).expect("read watch dir");
-                let mut removed = false;
-                for entry in entries {
-                    let entry = entry.expect("dir entry");
-                    let name = entry.file_name();
-                    let name = name.to_string_lossy();
-                    if name.starts_with(&prefix) {
-                        let _ = std::fs::remove_file(entry.path());
-                        removed_flag_for_thread.store(true, Ordering::SeqCst);
-                        removed = true;
-                    }
-                }
-                if removed {
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(1));
-            }
-        });
-
-        // Give the watcher time by making the write and sync non-trivial.
-        let contents = "x".repeat(4 * 1024 * 1024);
-        let err = write_state_atomically(&state_path, &contents).expect_err("expected error");
-        assert!(format!("{err:#}").contains("Failed to set permissions for temp state file"));
-
-        watcher.join().expect("watcher thread");
-        assert!(removed_flag.load(Ordering::SeqCst));
+        let message = format!("{err:#}");
+        assert!(message.contains("Failed to set permissions for temp state file"));
+        assert!(message.contains(".state.json.tmp-"));
+        let io_error = err
+            .root_cause()
+            .downcast_ref::<std::io::Error>()
+            .expect("root cause should be an I/O error");
+        assert_eq!(io_error.kind(), std::io::ErrorKind::NotFound);
+        assert_eq!(
+            std::fs::read_to_string(&state_path).expect("read preserved state"),
+            "previous state"
+        );
+        let entries = std::fs::read_dir(temp_dir.path())
+            .expect("read state directory")
+            .map(|entry| entry.expect("state directory entry").file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, [std::ffi::OsString::from("state.json")]);
     }
 
     #[test]

--- a/src/mux/client/tests.rs
+++ b/src/mux/client/tests.rs
@@ -676,14 +676,16 @@ fn test_mux_client_request_errors_when_reconnect_fails() {
         .expect("Create mux listener");
 
     let server = std::thread::spawn(move || {
-        let mut incoming = listener.incoming();
-
-        let mut stream = incoming
-            .next()
-            .expect("Missing initial connection")
-            .expect("Accept initial connection");
+        let mut stream = {
+            let mut incoming = listener.incoming();
+            incoming
+                .next()
+                .expect("Missing initial connection")
+                .expect("Accept initial connection")
+        };
 
         let _: MuxRequest = ipc::read_json(&mut stream).expect("Read initial request");
+        drop(listener);
         drop(stream);
     });
 
@@ -692,10 +694,8 @@ fn test_mux_client_request_errors_when_reconnect_fails() {
         client.request(&MuxRequest::Ping)
     })
     .expect_err("Expected mux client error");
-    assert!(
-        err.to_string()
-            .contains("Failed to resolve current executable")
-    );
+    assert_eq!(err.to_string(), "Failed to resolve current executable");
+    assert_eq!(err.root_cause().to_string(), "forced current_exe failure");
 
     server.join().expect("Server thread panicked");
 }

--- a/src/runtime/docker.rs
+++ b/src/runtime/docker.rs
@@ -35,6 +35,33 @@ struct PreparedRuntimeHome {
     codex_home_target: PathBuf,
 }
 
+#[derive(Default)]
+struct DockerHostPaths {
+    runtime_home: Option<DockerHostHome>,
+    ssh_auth_sock: Option<PathBuf>,
+}
+
+struct DockerHostHome {
+    home: PathBuf,
+    data_local_dir: PathBuf,
+    codex_home: PathBuf,
+}
+
+impl DockerHostPaths {
+    fn from_process_environment() -> Self {
+        let runtime_home = paths::home_dir().map(|home| DockerHostHome {
+            data_local_dir: paths::data_local_dir().unwrap_or_else(|| home.clone()),
+            codex_home: codex_home_dir(&home),
+            home,
+        });
+
+        Self {
+            runtime_home,
+            ssh_auth_sock: std::env::var_os("SSH_AUTH_SOCK").map(PathBuf::from),
+        }
+    }
+}
+
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub(super) fn wrap_exec(agent: &Agent, _settings: &Settings, command: &[String]) -> Vec<String> {
     let mut argv = exec_prefix(agent);
@@ -87,25 +114,15 @@ pub(super) fn image_build_required(settings: &Settings, program: &str) -> Result
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub(super) fn ensure_container(agent: &Agent, settings: &Settings) -> Result<()> {
-    let home = paths::home_dir();
-    let data_local_dir = paths::data_local_dir();
-    let ssh_auth_sock = std::env::var_os("SSH_AUTH_SOCK").map(PathBuf::from);
-    ensure_container_with_paths(
-        agent,
-        settings,
-        home.as_deref(),
-        data_local_dir.as_deref(),
-        ssh_auth_sock.as_deref(),
-    )
+    let host_paths = DockerHostPaths::from_process_environment();
+    ensure_container_with_paths(agent, settings, &host_paths)
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn ensure_container_with_paths(
     agent: &Agent,
     settings: &Settings,
-    home: Option<&Path>,
-    data_local_dir: Option<&Path>,
-    ssh_auth_sock: Option<&Path>,
+    host_paths: &DockerHostPaths,
 ) -> Result<()> {
     check_available()?;
     ensure_image_ready(settings, &agent.program)?;
@@ -125,8 +142,13 @@ fn ensure_container_with_paths(
                     );
                 }
                 remove_container_by_name(&name)?;
-            } else if let Some(home) = home {
-                refresh_runtime_home_for_reuse_with_data_local_dir(agent, home, data_local_dir)?;
+            } else if let Some(runtime_home) = host_paths.runtime_home.as_ref() {
+                refresh_runtime_home_for_reuse_in(
+                    agent,
+                    &runtime_home.home,
+                    &runtime_home.data_local_dir,
+                    &runtime_home.codex_home,
+                )?;
                 if is_running {
                     return Ok(());
                 }
@@ -167,11 +189,11 @@ fn ensure_container_with_paths(
         cmd.args(["--user", &user]);
     }
 
-    if let Some(home) = home {
-        configure_home_mounts_with_data_local_dir(&mut cmd, agent, home, data_local_dir)?;
+    if let Some(runtime_home) = host_paths.runtime_home.as_ref() {
+        configure_home_mounts(&mut cmd, agent, runtime_home)?;
     }
 
-    configure_ssh_auth_sock_mount_from(&mut cmd, ssh_auth_sock);
+    configure_ssh_auth_sock_mount_from(&mut cmd, host_paths.ssh_auth_sock.as_deref());
     configure_repo_metadata_mounts(&mut cmd, agent);
 
     cmd.args(["-w", &display_path(&worktree_target)]);
@@ -361,13 +383,18 @@ fn codex_home_dir(home: &Path) -> PathBuf {
     std::env::var_os("CODEX_HOME").map_or_else(|| home.join(".codex"), PathBuf::from)
 }
 
-fn configure_home_mounts_with_data_local_dir(
+fn configure_home_mounts(
     cmd: &mut Command,
     agent: &Agent,
-    home: &Path,
-    data_local_dir: Option<&Path>,
+    runtime_home: &DockerHostHome,
 ) -> Result<()> {
-    let prepared_home = prepare_runtime_home_with_data_local_dir(agent, home, data_local_dir)?;
+    let home = &runtime_home.home;
+    let prepared_home = prepare_runtime_home_in(
+        agent,
+        home,
+        &runtime_home.data_local_dir,
+        &runtime_home.codex_home,
+    )?;
     let home_target = container_target_path(home);
     let codex_home_target = container_target_path(&prepared_home.codex_home_target);
     cmd.arg("-e").arg(format!("HOME={}", home_target.display()));
@@ -560,34 +587,6 @@ fn resolved_symlink_target(path: &Path, worktree: &Path, link_target: &Path) -> 
         path.parent().unwrap_or(worktree).join(link_target)
     };
     resolved.canonicalize().unwrap_or(resolved)
-}
-
-fn prepare_runtime_home_with_data_local_dir(
-    agent: &Agent,
-    home: &Path,
-    data_local_dir: Option<&Path>,
-) -> Result<PreparedRuntimeHome> {
-    let data_local_dir = data_local_dir
-        .map(Path::to_path_buf)
-        .or_else(paths::data_local_dir)
-        .or_else(paths::home_dir)
-        .unwrap_or_else(std::env::temp_dir);
-    let codex_home_target = codex_home_dir(home);
-    prepare_runtime_home_in(agent, home, &data_local_dir, &codex_home_target)
-}
-
-fn refresh_runtime_home_for_reuse_with_data_local_dir(
-    agent: &Agent,
-    home: &Path,
-    data_local_dir: Option<&Path>,
-) -> Result<()> {
-    let data_local_dir = data_local_dir
-        .map(Path::to_path_buf)
-        .or_else(paths::data_local_dir)
-        .or_else(paths::home_dir)
-        .unwrap_or_else(std::env::temp_dir);
-    let codex_home_target = codex_home_dir(home);
-    refresh_runtime_home_for_reuse_in(agent, home, &data_local_dir, &codex_home_target)
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -1693,6 +1692,18 @@ mod tests {
         agent.runtime = AgentRuntime::Docker;
         agent.mux_session = "tenex-ABCD1234-root".to_string();
         agent
+    }
+
+    #[cfg(unix)]
+    fn docker_host_paths(home: &Path, data_local_dir: &Path, codex_home: &Path) -> DockerHostPaths {
+        DockerHostPaths {
+            runtime_home: Some(DockerHostHome {
+                home: home.to_path_buf(),
+                data_local_dir: data_local_dir.to_path_buf(),
+                codex_home: codex_home.to_path_buf(),
+            }),
+            ssh_auth_sock: None,
+        }
     }
 
     #[test]
@@ -4272,7 +4283,7 @@ command = "docker"
         let host_home = temp.path().join("host-home");
         let data_local_dir = temp.path().join("xdg-data");
         let worktree = temp.path().join("worktree");
-        let host_codex_home = host_home.join(".codex");
+        let host_codex_home = temp.path().join("host-codex-home");
         let host_claude_dir = host_home.join(".claude");
         let log = temp.path().join("docker.log");
         fs::create_dir_all(&worktree).unwrap();
@@ -4281,7 +4292,11 @@ command = "docker"
         fs::create_dir_all(host_home.join(".ssh")).unwrap();
         fs::create_dir_all(host_home.join(".config").join("ssh")).unwrap();
         fs::write(host_codex_home.join("config.toml"), "model = \"gpt-5.4\"\n").unwrap();
-        fs::write(host_codex_home.join("auth.json"), r#"{"token":"old"}"#).unwrap();
+        fs::write(
+            host_codex_home.join("auth.json"),
+            r#"{"token":"synthetic-old"}"#,
+        )
+        .unwrap();
         fs::write(
             host_claude_dir.join("settings.json"),
             r#"{"permissions":{"defaultMode":"plan"},"hooks":{"Stop":[]}}"#,
@@ -4305,7 +4320,11 @@ command = "docker"
             "updated-host-key\n",
         )
         .unwrap();
-        fs::write(host_codex_home.join("auth.json"), r#"{"token":"new"}"#).unwrap();
+        fs::write(
+            host_codex_home.join("auth.json"),
+            r#"{"token":"synthetic-new"}"#,
+        )
+        .unwrap();
         fs::write(
             host_claude_dir.join("settings.json"),
             r#"{"permissions":{"defaultMode":"acceptEdits"}}"#,
@@ -4319,21 +4338,16 @@ command = "docker"
             current_container_layout_hash(),
         );
         let script = write_fake_docker_script(&temp, &script_body);
+        let host_paths = docker_host_paths(&host_home, &data_local_dir, &host_codex_home);
 
         with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(
-                &agent,
-                &Settings::default(),
-                Some(&host_home),
-                Some(&data_local_dir),
-                None,
-            )
-            .unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &host_paths).unwrap();
         });
 
-        assert_eq!(
-            fs::read_to_string(prepared.codex_home_source.join("auth.json")).unwrap(),
-            r#"{"token":"new"}"#
+        assert!(
+            fs::read(prepared.codex_home_source.join("auth.json")).unwrap()
+                == br#"{"token":"synthetic-new"}"#,
+            "staged auth did not match the synthetic fixture"
         );
         assert!(
             fs::read_to_string(prepared.home_source.join(".claude").join("settings.json"))
@@ -4374,16 +4388,10 @@ command = "docker"
                 current_container_layout_hash(),
             ),
         );
+        let host_paths = docker_host_paths(&host_home, &data_local_dir, &host_home.join(".codex"));
 
         with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(
-                &agent,
-                &Settings::default(),
-                Some(&host_home),
-                Some(&data_local_dir),
-                None,
-            )
-            .unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &host_paths).unwrap();
         });
 
         let log_contents = fs::read_to_string(&log).unwrap();
@@ -4413,16 +4421,10 @@ command = "docker"
                 current_container_layout_hash(),
             ),
         );
+        let host_paths = docker_host_paths(&host_home, &data_local_dir, &host_home.join(".codex"));
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(
-                &agent,
-                &Settings::default(),
-                Some(&host_home),
-                Some(&data_local_dir),
-                None,
-            )
-            .unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &host_paths).unwrap_err()
         });
         let message = err.to_string();
         assert!(message.contains("Failed to start Docker container"));
@@ -4452,7 +4454,8 @@ command = "docker"
         );
 
         with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap();
         });
 
         let log_contents = fs::read_to_string(&log).unwrap();
@@ -4483,7 +4486,8 @@ command = "docker"
         );
 
         with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap();
         });
 
         let log_contents = fs::read_to_string(&log).unwrap();
@@ -4511,7 +4515,8 @@ command = "docker"
         );
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap_err()
         });
         let message = err.to_string();
         assert!(message.contains("Failed to start Docker container"));
@@ -4540,7 +4545,8 @@ command = "docker"
         );
 
         with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap();
         });
 
         let log_contents = fs::read_to_string(&log).unwrap();
@@ -4570,7 +4576,8 @@ command = "docker"
 
         with_docker_program_override_for_tests(script, || {
             let _user_guard = set_docker_user_override_for_tests(None);
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap();
         });
 
         let log_contents = fs::read_to_string(&log).unwrap();
@@ -4597,7 +4604,8 @@ command = "docker"
         );
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap_err()
         });
 
         let message = err.to_string();
@@ -4631,16 +4639,10 @@ command = "docker"
                 current_container_layout_hash(),
             ),
         );
+        let host_paths = docker_host_paths(&host_home, &data_local_dir, &host_home.join(".codex"));
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(
-                &agent,
-                &Settings::default(),
-                Some(&host_home),
-                Some(&data_local_dir),
-                None,
-            )
-            .unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &host_paths).unwrap_err()
         });
 
         let message = err.to_string();
@@ -4666,7 +4668,8 @@ command = "docker"
         );
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap_err()
         });
         let message = err.to_string();
         assert!(message.contains("Failed to inspect Docker container"));
@@ -4694,7 +4697,8 @@ command = "docker"
         );
 
         with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap();
         });
 
         let log_contents = fs::read_to_string(&log).unwrap();
@@ -4723,16 +4727,10 @@ command = "docker"
                 default_worker_dockerfile_hash(),
             ),
         );
+        let host_paths = docker_host_paths(&host_home, &data_local_file, &host_home.join(".codex"));
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(
-                &agent,
-                &Settings::default(),
-                Some(&host_home),
-                Some(&data_local_file),
-                None,
-            )
-            .unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &host_paths).unwrap_err()
         });
         assert!(
             err.to_string()
@@ -4759,7 +4757,8 @@ command = "docker"
         );
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap_err()
         });
         let message = err.to_string();
         assert!(message.contains("Failed to create Docker container"));
@@ -4782,7 +4781,8 @@ command = "docker"
         );
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap_err()
         });
         let message = err.to_string();
         assert!(message.contains("Failed to inspect Docker image"));
@@ -4808,7 +4808,8 @@ command = "docker"
         );
 
         let err = with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(&agent, &Settings::default(), None, None, None).unwrap_err()
+            ensure_container_with_paths(&agent, &Settings::default(), &DockerHostPaths::default())
+                .unwrap_err()
         });
         let message = err.to_string();
         assert!(message.contains("Failed to inspect Docker container"));
@@ -4954,7 +4955,7 @@ command = "docker"
         let host_home = temp.path().join("host-home");
         let data_local_dir = temp.path().join("xdg-data");
         let worktree = temp.path().join("worktree");
-        let host_codex_home = host_home.join(".codex");
+        let host_codex_home = temp.path().join("host-codex-home");
         let host_gh_dir = host_home.join(".config").join("gh");
         let log = temp.path().join("docker.log");
         fs::create_dir_all(&worktree).unwrap();
@@ -4983,16 +4984,10 @@ command = "docker"
                 default_worker_dockerfile_hash(),
             ),
         );
+        let host_paths = docker_host_paths(&host_home, &data_local_dir, &host_codex_home);
 
         with_docker_program_override_for_tests(script, || {
-            ensure_container_with_paths(
-                &agent,
-                &Settings::default(),
-                Some(&host_home),
-                Some(&data_local_dir),
-                None,
-            )
-            .unwrap();
+            ensure_container_with_paths(&agent, &Settings::default(), &host_paths).unwrap();
         });
 
         let log_contents = fs::read_to_string(&log).unwrap();
@@ -5028,20 +5023,17 @@ command = "docker"
 
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
+        let codex_home = temp.path().join("codex-home");
         let data_local_dir = temp.path().join("xdg-data");
         let worktree = temp.path().join("worktree");
         let log = temp.path().join("docker.log");
         let path = std::env::var("PATH").unwrap_or_default();
         let prefixed_path = format!("{}:{path}", temp.path().display());
-        fs::create_dir_all(home.join(".codex").join("sessions")).unwrap();
+        fs::create_dir_all(codex_home.join("sessions")).unwrap();
         fs::create_dir_all(home.join(".ssh")).unwrap();
         fs::create_dir_all(home.join(".config").join("ssh")).unwrap();
         fs::create_dir_all(&worktree).unwrap();
-        fs::write(
-            home.join(".codex").join("config.toml"),
-            "model = \"gpt-5.4\"\n",
-        )
-        .unwrap();
+        fs::write(codex_home.join("config.toml"), "model = \"gpt-5.4\"\n").unwrap();
         fs::write(home.join(".ssh").join("config"), "Host test\n").unwrap();
         fs::write(
             home.join(".config").join("ssh").join("config"),
@@ -5065,6 +5057,7 @@ command = "docker"
             .env(ENSURE_CONTAINER_CHILD_FLAG, "1")
             .env(ENSURE_CONTAINER_WORKTREE_VAR, &worktree)
             .env("HOME", &home)
+            .env("CODEX_HOME", &codex_home)
             .env("XDG_DATA_HOME", &data_local_dir)
             .env("PATH", prefixed_path)
             .output()
@@ -5076,6 +5069,7 @@ command = "docker"
         let log_contents = fs::read_to_string(&log).unwrap();
         assert!(log_contents.contains("run -d --init"));
         assert!(log_contents.contains(&format!("HOME={}", home.display())));
+        assert!(log_contents.contains(&format!("CODEX_HOME={}", codex_home.display())));
         assert!(log_contents.contains(&format!(
             "-v {}:{}",
             worktree.display(),
@@ -5219,15 +5213,11 @@ command = "docker"
                 inspect_count.display()
             ),
         );
+        let host_paths = docker_host_paths(&host_home, &data_local_dir, &host_home.join(".codex"));
 
         with_docker_program_override_for_tests(script, || {
-            let result = ensure_container_with_paths(
-                &docker_agent(),
-                &Settings::default(),
-                Some(&host_home),
-                Some(&data_local_dir),
-                None,
-            );
+            let result =
+                ensure_container_with_paths(&docker_agent(), &Settings::default(), &host_paths);
             assert!(result.is_err());
             let err = result
                 .err()


### PR DESCRIPTION
## Summary

- Replace the polling-based storage failure test with a direct atomic-commit failure boundary.
- Make the mux reconnect test close its listener before exposing the failed stream.
- Resolve Docker host paths once so synthetic fixtures cannot fall through to a live `CODEX_HOME`.
- Strip Git hook-local repository variables before every local Cargo hook command.
- Add a disposable-repository regression that proves fixture commits preserve the outer HEAD, index tree, raw index, and gitdir.

## Scope

This is a staged repair for #137. It does not close #137. Coverage de-exclusion, coverage identity attestation, and the remaining receipt-pipeline work stay open.

## Validation

- Storage failure test passed 100 normal runs and 25 coverage runs.
- Mux reconnect test passed 500 normal runs and 100 coverage runs.
- Both Docker regressions passed 26 normal runs and 11 coverage runs each.
- All 178 Docker module tests passed in normal and coverage profiles.
- The complete normal test suite passed with simulated `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` hook contamination while preserving the exact branch and index.
- Strict clippy, formatting, Python syntax, hook unit tests, and diff checks passed.
- The complete theoretical-max gate passed on Linux, macOS, and Windows WSL2 in one continuous execution for the final tree.
- Independent correctness and concept-density reviews approved the final tree.

Refs #137
