### PR TITLE
ci: preserve every master validation run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pre-commit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,6 +138,14 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: ci-concurrency-policy
+        name: CI concurrency policy
+        entry: python scripts/ci/test_ci_concurrency.py
+        language: python
+        additional_dependencies:
+          - PyYAML==6.0.3
+        pass_filenames: false
+
       - id: cross-os-theoretical-max
         name: "commit: enforce cross-OS theoretical max coverage"
         entry: python3 scripts/precommit/pre_push_theoretical_max_gate.py

--- a/scripts/ci/test_ci_concurrency.py
+++ b/scripts/ci/test_ci_concurrency.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
+EXPECTED_CONCURRENCY = {
+    "group": (
+        "ci-${{ github.workflow }}-"
+        "${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+    ),
+    "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
+}
+
+
+class CiConcurrencyTests(unittest.TestCase):
+    def test_workflow_uses_event_specific_concurrency_contract(self) -> None:
+        workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        self.assertIsInstance(workflow, dict)
+        self.assertEqual(workflow.get("concurrency"), EXPECTED_CONCURRENCY)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- give every push CI run a unique concurrency group so a later master push cannot cancel it
- retain stable ref-based cancellation for superseded pull request runs
- enforce the exact event-specific policy through a pinned structural pre-commit check

## Validation

- direct CI concurrency unit test passed
- focused pre-commit hook passed
- independent correctness review approved with no findings
- independent concept-density review approved with no findings
- full local cross-OS theoretical-max gate passed in one uninterrupted run on Linux, macOS, and Windows WSL2
- reviewed HEAD tree and post-gate index tree both equal `d4951a1b98eddd63bb85a68fb546e2de27a3a8ce`

GitHub acceptance still requires all seven checks to pass on this exact PR head on attempt 1, followed by all seven checks on the exact merge commit without cancellation or rerun.

Closes #157