### PR TITLE
chore: adopt Rust 1.97.1 and apply Hawk cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: "1.91.0"
+          toolchain: "1.97.1"
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: "1.91.0"
+          toolchain: "1.97.1"
       - uses: Swatinem/rust-cache@v2
       - name: Start Tenex
         run: cargo run --locked --bin tenex -- --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tenex"
 version = "1.0.10"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.97.1"
 resolver = "3"
 authors = ["Quinten Lisowe"]
 description = "Terminal multiplexer for AI coding agents"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Tenex runs AI coding agents in one terminal interface. In a Git repository, each
 - Git for worktree isolation and all Git actions.
 - GitHub CLI `gh` for opening pull requests.
 - Cargo for installation and in-app updates.
-- Rust 1.91 or newer when you build from source.
+- Rust 1.97.1 or newer when you build from source.
 - Docker with a running daemon if you enable the Docker runtime.
 
 Tenex includes its own terminal multiplexer. It does not require tmux or another external multiplexer.

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91-bookworm
+FROM rust:1.97.1-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
     NPM_CONFIG_UPDATE_NOTIFIER=false \

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,4 @@
+[[production]]
+package = "tenex"
+bin = "tenex"
+reason = "shipped terminal multiplexer binary"

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,4 +1,0 @@
-[[production]]
-package = "tenex"
-bin = "tenex"
-reason = "shipped terminal multiplexer binary"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/src/agent/storage.rs
+++ b/src/agent/storage.rs
@@ -815,7 +815,7 @@ impl Storage {
 
     /// Helper to recursively add visible agents with pre-computed info
     #[expect(
-        clippy::only_used_in_recursion,
+        clippy::self_only_used_in_recursion,
         reason = "&self is needed for lifetime 'a to tie result to Storage"
     )]
     fn add_visible_with_info_recursive<'a>(

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -173,7 +173,7 @@ impl AppData {
         self.ui.set_status(message);
     }
 
-    pub(crate) fn synthesis_target_descendants(&self, parent_id: Uuid) -> Vec<&Agent> {
+    fn synthesis_target_descendants(&self, parent_id: Uuid) -> Vec<&Agent> {
         self.storage
             .descendants(parent_id)
             .into_iter()
@@ -239,7 +239,7 @@ impl AppData {
         subtree_ids
     }
 
-    pub(crate) fn is_synthesis_marked(&self, agent_id: Uuid) -> bool {
+    fn is_synthesis_marked(&self, agent_id: Uuid) -> bool {
         self.synthesis_marks.contains(&agent_id)
     }
 
@@ -255,7 +255,7 @@ impl AppData {
         self.toggle_synthesis_mark(agent_id)
     }
 
-    pub(crate) fn toggle_synthesis_mark(&mut self, agent_id: Uuid) -> bool {
+    fn toggle_synthesis_mark(&mut self, agent_id: Uuid) -> bool {
         if !self.is_synthesis_mark_eligible(agent_id) {
             return false;
         }

--- a/src/app/handlers/agent_lifecycle.rs
+++ b/src/app/handlers/agent_lifecycle.rs
@@ -217,8 +217,7 @@ impl Actions {
             // Try to get existing worktree info
             let (existing_branch, existing_commit) = worktree_mgr
                 .worktree_head_info(&branch)
-                .map(|(b, c)| (Some(b), Some(c)))
-                .unwrap_or((None, None));
+                .map_or((None, None), |(b, c)| (Some(b), Some(c)));
 
             app_data.spawn.worktree_conflict = Some(WorktreeConflictInfo {
                 title: title.to_string(),
@@ -273,7 +272,7 @@ impl Actions {
     }
 
     /// Internal function to actually create the agent after conflict resolution
-    pub(crate) fn create_agent_internal(
+    fn create_agent_internal(
         self,
         app_data: &mut AppData,
         repo_path: &Path,

--- a/src/app/handlers/git_ops/merge.rs
+++ b/src/app/handlers/git_ops/merge.rs
@@ -128,7 +128,7 @@ impl Actions {
     }
 
     /// Find the worktree path for a branch, if one exists
-    pub(super) fn find_worktree_for_branch(
+    fn find_worktree_for_branch(
         repo_path: &std::path::Path,
         branch: &str,
     ) -> Result<Option<std::path::PathBuf>> {

--- a/src/app/handlers/git_ops/mod.rs
+++ b/src/app/handlers/git_ops/mod.rs
@@ -18,7 +18,7 @@ use super::Actions;
 
 impl Actions {
     /// Spawn a terminal for resolving conflicts
-    pub(crate) fn spawn_conflict_terminal(
+    fn spawn_conflict_terminal(
         app_data: &mut AppData,
         title: &str,
         startup_command: &str,

--- a/src/app/handlers/mod.rs
+++ b/src/app/handlers/mod.rs
@@ -26,11 +26,11 @@ use crate::action::{CancelAction, ConfirmYesAction, SubmitAction, UnfocusPreview
 #[derive(Debug, Clone, Copy)]
 pub struct Actions {
     /// Mux session manager
-    pub(crate) session_manager: SessionManager,
+    session_manager: SessionManager,
     /// Output capture
-    pub(crate) output_capture: OutputCapture,
+    output_capture: OutputCapture,
     /// Raw output stream
-    pub(crate) output_stream: OutputStream,
+    output_stream: OutputStream,
 }
 
 impl Actions {

--- a/src/app/handlers/swarm.rs
+++ b/src/app/handlers/swarm.rs
@@ -533,8 +533,7 @@ impl Actions {
 
         let (existing_branch, existing_commit) = worktree_mgr
             .worktree_head_info(&branch)
-            .map(|(b, c)| (Some(b), Some(c)))
-            .unwrap_or((None, None));
+            .map_or((None, None), |(b, c)| (Some(b), Some(c)));
 
         app_data.spawn.worktree_conflict = Some(WorktreeConflictInfo {
             title: root_title,

--- a/src/app/handlers/sync.rs
+++ b/src/app/handlers/sync.rs
@@ -320,7 +320,7 @@ impl Actions {
         self.respawn_missing_agents_in_data(&mut app.data)
     }
 
-    pub(crate) fn respawn_missing_agents_in_data(self, app_data: &mut AppData) -> Result<()> {
+    fn respawn_missing_agents_in_data(self, app_data: &mut AppData) -> Result<()> {
         let roots = stored_root_agents(app_data);
         if roots.is_empty() {
             return Ok(());

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -151,9 +151,8 @@ pub fn ensure_tenex_excluded(repo_path: &Path) -> Result<()> {
     // buffer without a bound. Non-regular paths fall through to the append open so the OS returns
     // the path error.
     if exclude_path.exists() {
-        let should_scan_existing = fs::metadata(&exclude_path)
-            .map(|metadata| metadata.is_file())
-            .unwrap_or(false);
+        let should_scan_existing =
+            fs::metadata(&exclude_path).is_ok_and(|metadata| metadata.is_file());
 
         if should_scan_existing {
             let file = fs::File::open(&exclude_path)

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1194,9 +1194,8 @@ impl<'a> Manager<'a> {
             return Ok(());
         };
 
-        let parent_is_symlink = fs::symlink_metadata(parent)
-            .map(|m| m.file_type().is_symlink())
-            .unwrap_or(false);
+        let parent_is_symlink =
+            fs::symlink_metadata(parent).is_ok_and(|m| m.file_type().is_symlink());
         if parent_is_symlink {
             return Ok(());
         }

--- a/src/runtime/docker.rs
+++ b/src/runtime/docker.rs
@@ -290,7 +290,7 @@ const fn worker_image_tag(_settings: &Settings) -> &str {
     DEFAULT_DOCKER_IMAGE
 }
 
-pub(super) fn container_name(agent: &Agent) -> String {
+fn container_name(agent: &Agent) -> String {
     let mut name = format!("tenex-runtime-{}", agent.effective_runtime_scope());
     name.make_ascii_lowercase();
     name.chars()

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -587,10 +587,10 @@ fn run_loop(
     let mut last_preview_follow = app.data.ui.preview_follow;
     let mut last_preview_update = Instant::now();
     // Diff refresh is expensive; throttle tick-based updates.
-    let diff_refresh_interval = Duration::from_millis(1000);
+    let diff_refresh_interval = Duration::from_secs(1);
     let mut last_diff_update = Instant::now();
     // Commits refresh is cheap; still throttle tick-based updates.
-    let commits_refresh_interval = Duration::from_millis(1000);
+    let commits_refresh_interval = Duration::from_secs(1);
     let mut last_commits_update = Instant::now();
     let mut last_status_sync = Instant::now();
     let mut last_pane_activity_sync = Instant::now();

--- a/src/tui/render/modals/branch.rs
+++ b/src/tui/render/modals/branch.rs
@@ -112,7 +112,7 @@ pub fn render_branch_selector_overlay(frame: &mut Frame<'_>, app: &App) {
     lines.push(Line::from(vec![
         Span::styled("Search: ", Style::default().fg(colors::TEXT_DIM)),
         Span::styled(
-            format!("{}_", &app.data.review.filter),
+            format!("{}_", app.data.review.filter),
             Style::default().fg(colors::TEXT_PRIMARY),
         ),
     ]));

--- a/src/tui/render/modals/input.rs
+++ b/src/tui/render/modals/input.rs
@@ -231,7 +231,7 @@ pub fn render_rename_overlay(frame: &mut Frame<'_>, app: &App) {
         )),
         Line::from(""),
         Line::from(Span::styled(
-            format!("{}_", &app.data.input.buffer),
+            format!("{}_", app.data.input.buffer),
             Style::default()
                 .fg(colors::TEXT_PRIMARY)
                 .add_modifier(Modifier::BOLD),

--- a/src/tui/render/modals/models.rs
+++ b/src/tui/render/modals/models.rs
@@ -42,7 +42,7 @@ pub fn render_model_selector_overlay(frame: &mut Frame<'_>, app: &App) {
     lines.push(Line::from(vec![
         Span::styled("Filter: ", Style::default().fg(colors::TEXT_DIM)),
         Span::styled(
-            format!("{}_", &app.data.model_selector.filter),
+            format!("{}_", app.data.model_selector.filter),
             Style::default().fg(colors::TEXT_PRIMARY),
         ),
     ]));


### PR DESCRIPTION
## Summary

- pin Tenex to stable Rust 1.97.1 across Cargo metadata, the local toolchain, CI, documentation, and the Docker worker image
- apply all 11 non-breaking restricted-visibility fixes from a one-time Hawk run without adding permanent Hawk configuration
- update code patterns for the Rust 1.97.1 Clippy lint set

## Hawk results

The one-time full Hawk scan also reported 131 dead public items and 504 public items that could be restricted for the binary product. Applying that broad fix changes the public library API and turns externally reachable APIs into dead code under the existing `-D warnings` policy, so this PR does not mechanically delete or hide those APIs.

## Verification

- `cargo fmt --check`
- `cargo clippy --lib --bins -- -D warnings`
- `cargo run --locked --bin tenex -- --version`
- one-time Hawk restricted-visibility fix pass completed with no remaining findings in that lint class
- `rustc --version` reports 1.97.1